### PR TITLE
Refactor handling of computation limits

### DIFF
--- a/src/core/Action.ml
+++ b/src/core/Action.ml
@@ -12,8 +12,7 @@ type run_provers = {
   dirs: Subdir.t list; (* list of directories to examine *)
   provers: Prover.t list;
   pattern: string option;
-  timeout: int option;
-  memory: int option;
+  limits : Limit.All.t;
 }
 
 type git_fetch_action =
@@ -35,13 +34,14 @@ type t =
 
 let pp_run_provers out (self:run_provers) =
   let open Misc.Pp in
-  let {dirs; provers; timeout; memory; j; pattern; } = self in
-  Fmt.fprintf out "(@[<v1>run_provers%a%a%a%a%a%a@])"
+  let {dirs; provers; limits; j; pattern; } = self in
+  Fmt.fprintf out "(@[<v1>run_provers%a%a%a%a%a%a%a@])"
     (pp_f "dirs" (pp_l Subdir.pp)) dirs
     (pp_f "provers" (pp_l Prover.pp_name)) provers
     (pp_opt "pattern" pp_regex) pattern
-    (pp_opt "timeout" Fmt.int) timeout
-    (pp_opt "memory" Fmt.int) memory
+    (pp_opt "timeout" Limit.Time.pp) limits.time
+    (pp_opt "memory" Limit.Memory.pp) limits.memory
+    (pp_opt "stack" Limit.Stack.pp) limits.stack
     (pp_opt "j" Fmt.int) j
 
 let pp_git_fetch out = function

--- a/src/core/Definitions.mli
+++ b/src/core/Definitions.mli
@@ -37,6 +37,7 @@ val mk_run_provers :
   ?j:int ->
   ?timeout:int ->
   ?memory:int ->
+  ?stack:Stanza.stack_limit ->
   ?pattern:string ->
   paths:path list ->
   provers:string list ->

--- a/src/core/Limit.ml
+++ b/src/core/Limit.ml
@@ -90,7 +90,7 @@ module Memory = struct
     print_aux "G" n_giga;
     print_aux "M" n_mega;
     print_aux "k" n_kilo;
-    print_aux "" n
+    print_aux "" n_bytes
 
   (* Creation *)
   let mk ?(b=0) ?(k=0) ?(m=0) ?(g=0) ?(t=0) () =

--- a/src/core/Limit.ml
+++ b/src/core/Limit.ml
@@ -1,0 +1,203 @@
+(* This file is free software. See file "license" for more details. *)
+
+
+(* Time limits aka Timeouts *)
+module Time = struct
+
+  (* Timeout are stored in **seconds** *)
+  type t = int
+
+  (* The view of a time *)
+  type view =
+    | Seconds
+    | Minutes
+    | Hours (**)
+
+  (* useful constants *)
+  let t_min = 60
+  let t_hour = 60 * t_min
+
+  (* Usual functions *)
+  let hash = Hashtbl.hash
+  let compare (x : t) y = compare x y
+  let equal x y = compare x y = 0
+
+  (* printing *)
+  let pp out t =
+    CCFormat.fprintf out "%ds" t
+
+  (* Creation *)
+  let mk ?(s=0) ?(m=0) ?(h=0) () =
+    s + m * t_min + h * t_hour
+
+  let add x y = x + y
+
+  (* Int (i.e. partial) View *)
+  let as_int v t =
+    match v with
+    | Seconds -> t
+    | Minutes -> t / t_min
+    | Hours -> t / t_hour
+
+  (* Float view (more precise) *)
+  let as_float v t =
+    match v with
+    | Seconds -> float t
+    | Minutes -> float t /. float t_min
+    | Hours -> float t /. float t_hour
+
+end
+
+
+
+(* Memory limits *)
+module Memory = struct
+
+  (* Memory limits are stored in number of bytes *)
+  type t = int
+
+  (* View of a memory limits *)
+  type view =
+    | Bytes
+    | Kilobytes
+    | Megabytes
+    | Gigabytes
+    | Terabytes
+
+  (* useful constants *)
+  let s_k = 1_000
+  let s_m = 1_000 * s_k
+  let s_g = 1_000 * s_m
+  let s_t = 1_000 * s_g
+
+  (* Usual functions *)
+  let hash = Hashtbl.hash
+  let compare (x : t) y = compare x y
+  let equal x y = compare x y = 0
+
+  (* printing *)
+  let pp out n =
+    let aux n div = n / div, n mod div in
+    let n_tera, n = aux n s_t in
+    let n_giga, n = aux n s_g in
+    let n_mega, n = aux n s_m in
+    let n_kilo, n_bytes = aux n s_k in
+    let print_aux s n =
+      if n = 0 then ()
+      else CCFormat.fprintf out "%d%s" n s
+    in
+    print_aux "T" n_tera;
+    print_aux "G" n_giga;
+    print_aux "M" n_mega;
+    print_aux "k" n_kilo;
+    print_aux "" n
+
+  (* Creation *)
+  let mk ?(b=0) ?(k=0) ?(m=0) ?(g=0) ?(t=0) () =
+    b + k * s_k + m * s_m + g * s_g + t * s_t
+
+  (* Int View *)
+  let as_int v t =
+    match v with
+    | Bytes -> t
+    | Kilobytes -> t / s_k
+    | Megabytes -> t / s_m
+    | Gigabytes -> t / s_g
+    | Terabytes -> t / s_t
+
+  (* Access as floats *)
+  let as_float v t =
+    match v with
+    | Bytes -> float t
+    | Kilobytes -> float t /. float s_k
+    | Megabytes -> float t /. float s_m
+    | Gigabytes -> float t /. float s_g
+    | Terabytes -> float t /. float s_t
+
+
+end
+
+(* Stack size limit *)
+module Stack = struct
+
+  type t =
+    | Unlimited
+    | Limited of Memory.t
+
+  (* Usual functions *)
+  let hash = Hashtbl.hash
+  let compare (x : t) y = compare x y
+  let equal x y = compare x y = 0
+
+  (* Printing *)
+  let pp out = function
+    | Unlimited -> CCFormat.fprintf out "unlimited"
+    | Limited m -> Memory.pp out m
+
+end
+
+(* Structure to combine all currently supported limits *)
+module All = struct
+
+  (* Useful record to represent a complet set of limits for one run *)
+  type t = {
+    time : Time.t option;
+    memory : Memory.t option;
+    stack : Stack.t option;
+  }
+
+  (* Usual functions *)
+  let hash = Hashtbl.hash
+  let compare (x : t) y = compare x y
+  let equal x y = compare x y = 0
+
+  (* Printing *)
+  let pp out t =
+    CCFormat.fprintf out "(@[<v 1>limits%a%a%a@])"
+      (Misc.Pp.pp_opt "timeout" Time.pp) t.time
+      (Misc.Pp.pp_opt "memory" Memory.pp) t.memory
+      (Misc.Pp.pp_opt "stack" Stack.pp) t.stack
+
+  (* Creation *)
+  let mk ?time ?memory ?stack () =
+    { time; memory; stack; }
+
+  let update_time f t = { t with time = f t.time }
+  let update_memory f t = { t with memory = f t.memory }
+  let update_stack f t = { t with stack = f t.stack }
+
+
+  (* Combination of limits *)
+  let with_default ~default = function
+    | None -> default
+    | Some _ as res -> res
+
+  let with_defaults ~defaults t =
+    update_time (with_default ~default:defaults.time) @@
+    update_memory (with_default ~default:defaults.memory) @@
+    update_stack (with_default ~default:defaults.stack) @@ t
+
+  (* Exception for a missing limit *)
+  exception Limit_missing of string
+
+  (* Substitution of limits in a buffer *)
+  let subst_aux s to_string = function
+    | Some x -> Some (to_string x)
+    | None -> raise (Limit_missing s)
+
+  let substitute ~time_as ~memory_as ~stack_as t s =
+    match s with
+    | "memory" ->
+      subst_aux s CCFun.(Memory.as_int memory_as %> string_of_int) t.memory
+    | "timeout" | "time" ->
+      subst_aux s CCFun.(Time.as_int time_as %> string_of_int) t.time
+    | "stack" ->
+      subst_aux s (function
+          | Stack.Unlimited -> "unlimited"
+          | Stack.Limited m -> string_of_int @@ Memory.as_int stack_as m
+        ) t.stack
+    | _ -> None
+
+end
+
+

--- a/src/core/Limit.mli
+++ b/src/core/Limit.mli
@@ -1,0 +1,144 @@
+(* This file is free software. See file "license" for more details. *)
+
+(** {1 Time limits} *)
+module Time : sig
+
+  type t
+  (** Type used to represent timeouts *)
+
+  type view =
+    | Seconds
+    | Minutes
+    | Hours (**)
+  (** The different ways to view a time *)
+
+  val hash : t -> int
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  (** Usual functions *)
+
+  val pp : t CCFormat.printer
+  (** Printer *)
+
+  val mk : ?s:int -> ?m:int -> ?h:int -> unit -> t
+  (** Create a timeout of [~h] hours, [~m] minutes and
+      [~s] seconds. The arguments default to [0] is not provided. *)
+
+  val add : t -> t -> t
+  (** Add timeouts. *)
+
+  val as_int : view -> t -> int
+  (** View a time converted into the given view/units, truncating
+      the result. For instance: [as_int Minutes (mk ~s:90) = 1] *)
+
+  val as_float : view -> t -> float
+  (** View a time converted into the given view/units.
+      For instance: [as_float Minutes (mk ~s:90) = 1.5] *)
+
+end
+
+(** {1 Memory limits} *)
+module Memory : sig
+
+  type t
+  (** Type used to represent memory limits *)
+
+  type view =
+    | Bytes
+    | Kilobytes
+    | Megabytes
+    | Gigabytes
+    | Terabytes (**)
+  (** The different ways to view a memory limit *)
+
+  val hash : t -> int
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  (** Usual functions *)
+
+  val pp : t CCFormat.printer
+  (** Printer *)
+
+  val mk : ?b:int -> ?k:int -> ?m:int -> ?g:int -> ?t:int -> unit -> t
+  (** Create a memory limits of [~t] terabytes, [~g] gigabytes,
+      [~m] megabytes, [~k] kilobytes, and [~b] bytes. The arguments default
+      to [0] if not provided. *)
+
+  val as_int : view -> t -> int
+  (** View a memory size converted into the given view/units, truncating
+      the result. For instance: [as_int Kilobytes (mk ~b:1_500) = 1] *)
+
+  val as_float : view -> t -> float
+  (** View a memory size converted into the given view/units.
+      For instance: [as_float Kilobytes (mk ~b:1_500) = 1.5] *)
+
+end
+
+(** {1 Stack limits} *)
+module Stack : sig
+
+  type t =
+    | Unlimited
+    | Limited of Memory.t (**)
+  (** Stack size limits. *)
+
+  val hash : t -> int
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  (** Usual functions *)
+
+  val pp : t CCFormat.printer
+  (** Printer *)
+
+end
+
+(** {1 Set of limits} *)
+module All : sig
+
+  type t = {
+    time : Time.t option;
+    memory : Memory.t option;
+    stack : Stack.t option;
+  }
+  (** Type used to represent a set of (optional) limits,
+      including a time limit, a memory limit and a stack limit. *)
+
+  val hash : t -> int
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  (** Usual functions *)
+
+  val pp : t CCFormat.printer
+  (** Printer *)
+
+  val mk : ?time:Time.t -> ?memory:Memory.t -> ?stack:Stack.t -> unit -> t
+  (** Create a set of limits. *)
+
+  val update_time : (Time.t option -> Time.t option) -> t -> t
+  val update_memory : (Memory.t option -> Memory.t option) -> t -> t
+  val update_stack : (Stack.t option -> Stack.t option) -> t -> t
+  (** Update functions *)
+
+  val with_defaults : defaults:t -> t -> t
+  (** [with_defaults ~defaults t] is the same as t, except for limits
+      of [t] which were [None], in which case the value from [defaults]
+      is used (which can itself alos be [None]). *)
+
+  exception Limit_missing of string
+  (** Exception raised by {!substitute} when trying to substitute a
+      limit that was not provided. *)
+
+  val substitute :
+    time_as:Time.view ->
+    memory_as:Memory.view ->
+    stack_as:Memory.view ->
+    t -> (string -> string option)
+  (** Given a set of limits, and a view for each of these limits,
+      return a substitution function adequate for use with
+      {!Buffer.ass_substitute}.
+      @raise Limit_missing if a limit is neede for substitution
+        but not present in the argument. *)
+
+end
+
+

--- a/src/core/Problem.ml
+++ b/src/core/Problem.ml
@@ -76,7 +76,12 @@ let find_expect ?default_expect ~expect file : Res.t or_error =
       in
       try_ l
     | Dir.E_program {prover} ->
-      let raw = Prover.run ~timeout:1 ~memory:1_000 ~file prover in
+      let raw = Prover.run prover ~file
+          ~limits:(Limit.All.mk
+                     ~time:(Limit.Time.mk ~s:1 ())
+                     ~memory:(Limit.Memory.mk ~m:1 ())
+                     ())
+      in
       match Prover.analyze_p_opt prover raw, default_expect with
       | Some r, _ -> E.return r
       | None, Some r -> E.return r

--- a/src/core/Run_event.ml
+++ b/src/core/Run_event.ml
@@ -59,7 +59,7 @@ let to_db_prover_result (db:Db.t) (self:Prover.name Run_result.t) : _ or_error =
     self.problem.Problem.name
     (self.res |> Res.to_string)
     (self.problem.Problem.expected |> Res.to_string)
-    self.timeout
+    (self.timeout |> Limit.Time.as_int Seconds)
     self.raw.errcode
     self.raw.stdout
     self.raw.stderr
@@ -88,6 +88,7 @@ let of_db_map db ~f : _ list or_error =
            let pb =
              {Problem.name=pb_name; expected=Res.of_string ~tags expected}
            in
+           let timeout = Limit.Time.mk ~s:timeout () in
            let p =
              Run_result.make pname pb ~timeout ~res:(Res.of_string ~tags res)
                {errcode;stderr;stdout;rtime;utime;stime}

--- a/src/core/Run_prover_problem.mli
+++ b/src/core/Run_prover_problem.mli
@@ -8,8 +8,7 @@ type path = string
 type job_res = Prover.name Run_result.t
 
 val run :
-  timeout:int ->
-  memory:int ->
+  limits:Limit.All.t ->
   Prover.t ->
   Problem.t ->
   job_res or_error

--- a/src/core/Run_result.ml
+++ b/src/core/Run_result.ml
@@ -4,7 +4,7 @@ type +'a t = {
   program : 'a;
   problem : Problem.t;
   res : Res.t;
-  timeout : int;
+  timeout : Limit.Time.t;
   raw : Proc_run_result.t;
 }
 
@@ -14,13 +14,16 @@ let raw e = e.raw
 
 let map ~f e = { e with program = f e.program }
 
+let float_timeout self =
+  Limit.Time.as_float Seconds self.timeout
+
 let analyze_self_ (self:Prover.t t) =
   let res =
     match Prover.analyze_p_opt self.program self.raw with
     | Some x -> x
     | None ->
       if self.raw.errcode = 0 then Res.Unknown
-      else if self.raw.rtime > float self.timeout then Res.Timeout
+      else if self.raw.rtime > float_timeout self then Res.Timeout
       else Res.Error
   in
   { self with res }

--- a/src/core/Run_result.mli
+++ b/src/core/Run_result.mli
@@ -4,7 +4,7 @@ type +'a t = private {
   program : 'a;
   problem : Problem.t;
   res : Res.t;
-  timeout : int;
+  timeout : Limit.Time.t;
   raw : Proc_run_result.t;
 }
 
@@ -16,7 +16,7 @@ val map : f:('a -> 'b) -> 'a t -> 'b t
 
 val make_from_prover :
   Prover.t ->
-  timeout:int ->
+  timeout:Limit.Time.t ->
   Problem.t ->
   Proc_run_result.t ->
   Prover.name t
@@ -26,7 +26,7 @@ val analyze_self : Prover.t t -> Prover.name t
 
 val make:
   Prover.name ->
-  timeout:int ->
+  timeout:Limit.Time.t ->
   res:Res.t ->
   Problem.t ->
   Proc_run_result.t ->

--- a/src/core/Stanza.ml
+++ b/src/core/Stanza.ml
@@ -267,7 +267,7 @@ let dec_stack_limit : _ Se.D.decoder =
     "int", int >>= (fun s -> succeed (Limited s));
     "unlimited", string >>= function
       | "unlimited" -> succeed Unlimited
-      | s -> fail_sexp_f "expect 'unlimited' of an integer"
+      | _ -> fail_sexp_f "expect 'unlimited' or an integer"
   ]
 
 let dec_action : action Se.D.decoder =

--- a/src/core/Stanza.ml
+++ b/src/core/Stanza.ml
@@ -20,6 +20,10 @@ type version_field =
   | Version_git of {dir:string} (* compute by calling git *)
   | Version_cmd of {cmd:string}
 
+type stack_limit =
+  | Unlimited
+  | Limited of int
+
 (** A regex in Perl syntax *)
 type regex = string
 
@@ -32,6 +36,7 @@ type action =
       provers: string list;
       timeout: int option;
       memory: int option;
+      stack : stack_limit option;
     }
   | A_git_checkout of {
       dir: string;
@@ -53,6 +58,8 @@ type t =
 
       binary: string option; (** name of the program itself *)
       binary_deps: string list; (** list of binaries this depends on *)
+
+      ulimits : Ulimit.conf option; (** which limits to enforce using ulimit *)
 
       (* Result analysis *)
       unsat   : regex option;  (** regex for "unsat" *)
@@ -96,16 +103,21 @@ let pp_git_fetch out = function
   | GF_fetch -> Fmt.string out "fetch"
   | GF_pull -> Fmt.string out "pull"
 
+let pp_stack_limit out = function
+  | Unlimited -> Fmt.string out "unlimited"
+  | Limited i -> Fmt.int out i
+
 let rec pp_action out =
   let open Misc.Pp in
   function
-  | A_run_provers {dirs;provers;timeout;memory;pattern;} ->
-    Fmt.fprintf out "(@[<v>run_provers%a%a%a%a%a@])"
+  | A_run_provers {dirs;provers;timeout;memory;stack;pattern;} ->
+    Fmt.fprintf out "(@[<v>run_provers%a%a%a%a%a%a@])"
       (pp_f "dirs" (pp_l pp_str)) dirs
       (pp_f "provers" (pp_l pp_str)) provers
       (pp_opt "pattern" pp_regex) pattern
       (pp_opt "timeout" Fmt.int) timeout
       (pp_opt "memory" Fmt.int) memory
+      (pp_opt "stack" pp_stack_limit) stack
   | A_progn l -> Fmt.fprintf out "(@[progn %a@])" (pp_l pp_action) l
   | A_run_cmd s -> Fmt.fprintf out "(@[run_cmd %a@])" pp_regex s
   | A_git_checkout {dir;ref;fetch_first} ->
@@ -125,14 +137,15 @@ let pp out =
       (pp_opt "pattern" pp_regex) pattern
   | St_prover {
       name; cmd; version; unsat; sat; unknown; timeout; memory;
-      binary=_; binary_deps=_; custom;
+      binary=_; binary_deps=_; custom; ulimits;
     } ->
     let pp_custom out (x,y) =
       Fmt.fprintf out "(@[tag %a@ %a@])" pp_str x pp_regex y in
-    Fmt.fprintf out "(@[<v>prover%a%a%a%a%a%a%a%a%a@])"
+    Fmt.fprintf out "(@[<v>prover%a%a%a%a%a%a%a%a%a%a@])"
       (pp_f "name" pp_str) name
       (pp_f "cmd" pp_str) cmd
       (pp_opt "version" pp_version_field) version
+      (pp_opt "ulimits" Ulimit.pp) ulimits
       (pp_opt "sat" pp_regex) sat
       (pp_opt "unsat" pp_regex) unsat
       (pp_opt "unknown" pp_regex) unknown
@@ -211,6 +224,26 @@ let dec_version : _ Se.D.decoder =
       | s -> fail_sexp_f "invalid `version` constructor: %s" s);
   ]
 
+let dec_ulimits : _ Se.D.decoder =
+  let open Se.D in
+  let no_limits = Ulimit.mk ~time:false ~memory:false ~stack:false in
+  let none =
+    string >>= function
+    | "none" -> succeed no_limits
+    | _ -> fail_sexp_f {|expected "none"|}
+  in
+  let single_limit acc =
+    string >>= function
+    | "time" -> succeed { acc with Ulimit.time = true; }
+    | "memory" -> succeed { acc with Ulimit.memory = true; }
+    | "stack" -> succeed { acc with Ulimit.stack = true; }
+    | s -> fail_sexp_f "expected 'ulimit' stanzas (constructors: time|memory|stack, not %S)" s
+  in
+  one_of [
+    "atom", none;
+    "list", list_fold_left single_limit no_limits;
+  ]
+
 let list_or_singleton d =
   let open Se.D in
   value >>= fun s ->
@@ -228,6 +261,15 @@ let dec_fetch_first =
   | "pull" -> succeed GF_pull
   | _ -> fail_f "expected `fetch` or `pull`"
 
+let dec_stack_limit : _ Se.D.decoder =
+  let open Se.D in
+  one_of [
+    "int", int >>= (fun s -> succeed (Limited s));
+    "unlimited", string >>= function
+      | "unlimited" -> succeed Unlimited
+      | s -> fail_sexp_f "expect 'unlimited' of an integer"
+  ]
+
 let dec_action : action Se.D.decoder =
   let open Se.D in
   fix (fun self ->
@@ -238,7 +280,8 @@ let dec_action : action Se.D.decoder =
         field_opt "pattern" dec_regex >>= fun pattern ->
         field_opt "timeout" int >>= fun timeout ->
         field_opt "memory" int >>= fun memory ->
-        succeed @@ A_run_provers {dirs;provers;timeout;memory;pattern}
+        field_opt "stack" dec_stack_limit >>= fun stack ->
+        succeed @@ A_run_provers {dirs;provers;timeout;memory;stack;pattern}
       | "progn" -> list_or_singleton self >|= fun l -> A_progn l
       | "run_cmd" -> list1 string >|= fun s -> A_run_cmd s
       | "git_checkout" ->
@@ -277,10 +320,12 @@ let dec tags : (_ list * t) Se.D.decoder =
     field_opt "unknown" dec_regex >>= fun unknown ->
     field_opt "timeout" dec_regex >>= fun timeout ->
     field_opt "memory" dec_regex >>= fun memory ->
+    field_opt "ulimit" dec_ulimits >>= fun ulimits ->
     list_filter tag >>= fun custom ->
     succeed @@
     (tags, St_prover {
-      name; cmd; version; sat; unsat; unknown; timeout; memory; custom;
+        name; cmd; version; sat; unsat; unknown; timeout; memory; custom;
+        ulimits;
       binary=None;
       binary_deps=[]; (* TODO *)
     })

--- a/src/core/Test.ml
+++ b/src/core/Test.ml
@@ -1180,6 +1180,7 @@ end = struct
                   prover file)
            |> scope.unwrap
            |> (fun (res, file_expect, timeout, errcode, stdout, stderr, rtime, utime, stime) ->
+               (* Still needed ?! *)
                Gc.compact();
                Gc.full_major();
                Logs.info (fun k->k "got results 2");
@@ -1190,6 +1191,7 @@ end = struct
                Logs.debug (fun k->k"got expected %a" Res.pp expected);
                let res = Res.of_string ~tags res in
                Logs.debug (fun k->k"got res %a" Res.pp res);
+               let timeout = Limit.Time.mk ~s:timeout () in
                Run_result.make prover ~timeout ~res
                  {Problem.name=file; expected}
                  { Proc_run_result.errcode;stdout;stderr;rtime;utime;stime})

--- a/src/core/Ulimit.ml
+++ b/src/core/Ulimit.ml
@@ -1,0 +1,63 @@
+(* This file is free software. See file "license" for more details. *)
+
+(* A type to state which limits should be enforced by ulimit *)
+type conf = {
+  time : bool;
+  memory : bool;
+  stack : bool;
+}
+
+(* Creation *)
+let mk ~time ~memory ~stack =
+  { time; memory; stack; }
+
+(* Usual functions *)
+let hash = Hashtbl.hash
+let compare (x : conf) y = compare x y
+let equal x y = compare x y = 0
+
+(* Printing *)
+let pp out t =
+  if not t.time && not t.memory && not t.stack then
+    CCFormat.fprintf out "none"
+  else begin
+    CCFormat.fprintf out "(%a%a%a)"
+      CCFormat.string (if t.time then "time " else "")
+      CCFormat.string (if t.memory then "memory " else "")
+      CCFormat.string (if t.stack then "stack" else "")
+  end
+
+(* Creation *)
+let mk ~time ~memory ~stack =
+  { time; memory; stack; }
+
+(* Make a command to enforce a set of limits *)
+let cmd ~conf ~limits =
+  if not conf.time && not conf.memory && not conf.stack then
+    None
+  else begin
+    let buf = Buffer.create 32 in
+    let subst s =
+      (* this should be safe as we only use pattern recognized
+         by the Limit.All.substitute, hence it should never return
+         None *)
+      CCOpt.get_exn @@
+      Limit.All.substitute
+        ~memory_as:Megabytes
+        ~time_as:Seconds
+        ~stack_as:Megabytes
+        limits s
+    in
+    let add_str s = Buffer.add_substitute buf subst s in
+    Buffer.add_string buf "ulimit ";
+    if conf.time then add_str "-t $timeout";
+    if conf.memory then add_str "-Sv $memory";
+    if conf.stack then add_str "-s $stack";
+    Some (Buffer.contents buf)
+  end
+
+let prefix_cmd ?prefix ~cmd =
+  match prefix with
+  | None -> cmd
+  | Some s -> s ^ "; " ^ cmd
+

--- a/src/core/Ulimit.ml
+++ b/src/core/Ulimit.ml
@@ -27,10 +27,6 @@ let pp out t =
       CCFormat.string (if t.stack then "stack" else "")
   end
 
-(* Creation *)
-let mk ~time ~memory ~stack =
-  { time; memory; stack; }
-
 (* Make a command to enforce a set of limits *)
 let cmd ~conf ~limits =
   if not conf.time && not conf.memory && not conf.stack then

--- a/src/core/Ulimit.mli
+++ b/src/core/Ulimit.mli
@@ -1,0 +1,30 @@
+(* This file is free software. See file "license" for more details. *)
+
+(** {1 Ulimit handling of limits} *)
+
+type conf = {
+  time : bool;
+  memory : bool;
+  stack : bool;
+}
+(** The configuration of ulimit, aka which limits to enforce
+    via ulimit. *)
+
+val hash : conf -> int
+val equal : conf -> conf -> bool
+val compare : conf -> conf -> int
+(** Usual functions *)
+
+val pp : conf CCFormat.printer
+(** Printer *)
+
+val mk : time:bool -> memory:bool -> stack:bool -> conf
+(** Create a ulimit conf. *)
+
+val cmd : conf:conf -> limits:Limit.All.t -> string option
+(** Given a ulimit conf, and a set of limits, return an adequate command
+    (if any is necessary) to enforce the limits using ulimit. *)
+
+val prefix_cmd : ?prefix:string -> cmd:string -> string
+(** Adequately prefix the given command with the optional given prefix command. *)
+


### PR DESCRIPTION
This PR does a few things (all in one commit, which should be renamed now, :p ):
- first, avoid the double wrapping using ulimit that is currently used by benchpress
- add a computation limit for stack usage (to the existing timeout and memory limits)
- add the possibility for a prover to declare whether some of its computation limits should be enforced by ulimit or not (default is to enforce time and memory limits). This allows provers that can natively handle all computation limits internally to not be wrapped with ulimit.
- all of the code handling limits is refactored to introduce proper types and abstractions over computation limits, this allows to be a lot more safe about the units in which these limits are interpreted.
- the code for wrapping using ulimit is now in a module of its own