### PR TITLE
Add an option to specify an output database

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Most of the commands accept `-c <config file>` to specify which config files to 
   * `-F <file>` read list of problems from given file
   * `-p <prover1,prover2>` list of provers to use
   * `--task <profile>` specify which task to use
+  * `-o <file>` specify an output database file
 - `benchpress dir config` shows the configuration directory
 - `benchpress dir state` shows the directory where the state (benchmark results) is stored
 - `benchpress check-config <file>` to check that the file is valid configuration
@@ -60,7 +61,7 @@ Some internal parameters of benchpress can be set using environment variables:
 - "BENCHPRESS_BUSY_TIMEOUT" controls the busy timeout of the sql database used
   by benchpress, in miliseconds. Default is 3000.
 
-
+- "XDG_CONFIG_HOME" override the default value `$HOME/.config`.
 
 ### Web interface
 

--- a/src/bin/benchpress_bin.ml
+++ b/src/bin/benchpress_bin.ml
@@ -31,7 +31,7 @@ module Run = struct
     and pp_results =
       Arg.(value & opt bool true & info ["pp-results"] ~doc:"print results as they are found")
     and output = 
-      Arg.(value & opt (some string) None & info ["output"] ~doc:"output database file")
+      Arg.(value & opt (some string) None & info ["o"; "output"] ~doc:"output database file")
     and save =
       Arg.(value & opt bool true & info ["save"] ~doc:"save results on disk")
     and dir_file =

--- a/src/bin/benchpress_bin.ml
+++ b/src/bin/benchpress_bin.ml
@@ -18,18 +18,20 @@ module Run = struct
   let cmd =
     let open Cmdliner in
     let aux j pp_results dyn paths dir_file proof_dir defs task timeout memory
-        meta provers csv summary no_color save =
+        meta provers csv summary no_color output save =
       catch_err @@ fun () ->
       if no_color then CCFormat.set_color_default false;
       let dyn = if dyn then Some true else None in
       Run_main.main ~pp_results ?dyn ~j ?timeout ?memory ?csv ~provers
-        ~meta ?task ?summary ?dir_file ?proof_dir ~save defs paths ()
+        ~meta ?task ?summary ?dir_file ?proof_dir ?output ~save defs paths ()
     in
     let defs = Bin_utils.definitions_term
     and dyn =
       Arg.(value & flag & info ["progress"] ~doc:"print progress bar")
     and pp_results =
       Arg.(value & opt bool true & info ["pp-results"] ~doc:"print results as they are found")
+    and output = 
+      Arg.(value & opt (some string) None & info ["output"] ~doc:"output database file")
     and save =
       Arg.(value & opt bool true & info ["save"] ~doc:"save results on disk")
     and dir_file =
@@ -63,7 +65,7 @@ module Run = struct
     Cmd.v (Cmd.info ~doc "run")
       (Term.(const aux $ j $ pp_results $ dyn $ paths
              $ dir_file $ proof_dir $ defs $ task $ timeout $ memory
-             $ meta $ provers $ csv $ summary $ no_color $ save))
+             $ meta $ provers $ csv $ summary $ no_color $ output $ save))
 end
 
 module List_files = struct

--- a/src/core/Exec_action.ml
+++ b/src/core/Exec_action.ml
@@ -163,7 +163,10 @@ end = struct
       if save then (
         let db_file = 
           match output with 
-          | Some output -> output 
+          | Some output -> 
+              if Sys.file_exists output then
+                Error.failf "The file %s exists" output
+              else output 
           | None -> db_file_for_uuid ~timestamp uuid
         in
         Log.debug (fun k -> k"output database file %s" db_file);

--- a/src/core/Exec_action.mli
+++ b/src/core/Exec_action.mli
@@ -33,6 +33,7 @@ module Exec_run_provers : sig
     ?on_proof_check:(Test.proof_check_result -> unit) ->
     ?on_done:(Test_compact_result.t -> unit) ->
     ?interrupted:(unit -> bool) ->
+    ?output:string ->
     uuid:Uuidm.t ->
     save:bool ->
     expanded ->
@@ -67,6 +68,7 @@ end
 val dump_results_sqlite : Test_top_result.t -> unit
 
 val run :
+  ?output:string ->
   ?save:bool ->
   ?interrupted:(unit -> bool) ->
   ?cb_progress:cb_progress -> Definitions.t -> Action.t -> unit


### PR DESCRIPTION
This PR does two things: 
- add an option to specify a custom location for the output database. It is useful if you want to interface benchpress with other programs. 
- add a documentation about the support of XDG. It was not clear how to specify another directory than the default one.