### PR TITLE
Activate the WAL mode after creating the database file

### DIFF
--- a/src/bin/benchpress_bin.ml
+++ b/src/bin/benchpress_bin.ml
@@ -35,7 +35,7 @@ module Run = struct
     and save =
       Arg.(value & opt bool true & info ["save"] ~doc:"save results on disk")
     and wal_mode =
-      Arg.(value & opt bool false & info ["wal"] ~doc:"turn on the journal WAL mode")
+      Arg.(value & flag & info ["wal"] ~doc:"turn on the journal WAL mode")
     and dir_file =
       Arg.(value & opt (some string) None & info ["F"] ~doc:"file containing a list of files")
     and proof_dir =

--- a/src/bin/benchpress_bin.ml
+++ b/src/bin/benchpress_bin.ml
@@ -18,12 +18,12 @@ module Run = struct
   let cmd =
     let open Cmdliner in
     let aux j pp_results dyn paths dir_file proof_dir defs task timeout memory
-        meta provers csv summary no_color output save =
+        meta provers csv summary no_color output save wal_mode =
       catch_err @@ fun () ->
       if no_color then CCFormat.set_color_default false;
       let dyn = if dyn then Some true else None in
       Run_main.main ~pp_results ?dyn ~j ?timeout ?memory ?csv ~provers
-        ~meta ?task ?summary ?dir_file ?proof_dir ?output ~save defs paths ()
+        ~meta ?task ?summary ?dir_file ?proof_dir ?output ~save ~wal_mode defs paths ()
     in
     let defs = Bin_utils.definitions_term
     and dyn =
@@ -34,6 +34,8 @@ module Run = struct
       Arg.(value & opt (some string) None & info ["o"; "output"] ~doc:"output database file")
     and save =
       Arg.(value & opt bool true & info ["save"] ~doc:"save results on disk")
+    and wal_mode =
+      Arg.(value & opt bool false & info ["wal"] ~doc:"turn on the journal WAL mode")
     and dir_file =
       Arg.(value & opt (some string) None & info ["F"] ~doc:"file containing a list of files")
     and proof_dir =
@@ -65,7 +67,7 @@ module Run = struct
     Cmd.v (Cmd.info ~doc "run")
       (Term.(const aux $ j $ pp_results $ dyn $ paths
              $ dir_file $ proof_dir $ defs $ task $ timeout $ memory
-             $ meta $ provers $ csv $ summary $ no_color $ output $ save))
+             $ meta $ provers $ csv $ summary $ no_color $ output $ save $ wal_mode))
 end
 
 module List_files = struct

--- a/src/core/Exec_action.ml
+++ b/src/core/Exec_action.ml
@@ -170,7 +170,10 @@ end = struct
           | None -> db_file_for_uuid ~timestamp uuid
         in
         Log.debug (fun k -> k"output database file %s" db_file);
-        Sqlite3.db_open ~mutex:`FULL db_file
+        let db = Sqlite3.db_open ~mutex:`FULL db_file in
+        match Db.exec0 db "pragma journal_mode=WAL;" with
+        | Ok _ -> db
+        | Error rc -> Error.raise (Misc.err_of_db rc) 
       ) else
         Sqlite3.db_open ":memory:"
     in

--- a/src/core/Exec_action.ml
+++ b/src/core/Exec_action.ml
@@ -49,6 +49,7 @@ module Exec_run_provers : sig
     ?output:string ->
     uuid:Uuidm.t ->
     save:bool ->
+    wal_mode:bool ->
     expanded ->
     Test_top_result.t lazy_t * Test_compact_result.t
     (** Run the given prover(s) on the given problem set, obtaining results
@@ -155,7 +156,7 @@ end = struct
       ?(on_start=_nop) ?(on_solve = _nop) ?(on_start_proof_check=_nop)
       ?(on_proof_check = _nop) ?(on_done = _nop)
       ?(interrupted=fun _->false) ?output
-      ~uuid ~save
+      ~uuid ~save ~wal_mode
       (self:expanded) : _*_ =
     let start = Misc.now_s() in
     (* prepare DB *)
@@ -171,9 +172,11 @@ end = struct
         in
         Log.debug (fun k -> k"output database file %s" db_file);
         let db = Sqlite3.db_open ~mutex:`FULL db_file in
-        match Db.exec0 db "pragma journal_mode=WAL;" with
-        | Ok _ -> db
-        | Error rc -> Error.raise (Misc.err_of_db rc) 
+        if wal_mode then
+          match Db.exec0 db "pragma journal_mode=WAL;" with
+          | Ok _ -> db
+          | Error rc -> Error.raise (Misc.err_of_db rc)
+        else db
       ) else
         Sqlite3.db_open ":memory:"
     in

--- a/src/core/Exec_action.mli
+++ b/src/core/Exec_action.mli
@@ -36,6 +36,7 @@ module Exec_run_provers : sig
     ?output:string ->
     uuid:Uuidm.t ->
     save:bool ->
+    wal_mode:bool ->
     expanded ->
     Test_top_result.t lazy_t * Test_compact_result.t
     (** Run the given prover(s) on the given problem set, obtaining results


### PR DESCRIPTION
This PR activates the [WAL](https://sqlite.org/wal.html) mode in the output database file. 
Without activating this mode, it would be unsafe to read and write at the same time in the database. 
The mode is valuable to people who want to read the database with an external program before the end of the execution of benchpress.

According to the above documentation, the WAL mode reduces slightly the performances of Sqlite but the difference is not 
significant. 

I didn't add an option to activate or deactivate this mode but I can add it if you think it is a better design.