### PR TITLE
added `desktop_notification`, `no_failure` and `update` as command line options

### DIFF
--- a/src/bin/benchpress_bin.ml
+++ b/src/bin/benchpress_bin.ml
@@ -18,19 +18,21 @@ module Run = struct
   let cmd =
     let open Cmdliner in
     let aux j pp_results dyn paths dir_file proof_dir defs task timeout memory
-        meta provers csv summary no_color output save wal_mode =
+        meta provers csv summary no_color output save wal_mode
+        desktop_notification no_failure update =
       catch_err @@ fun () ->
       if no_color then CCFormat.set_color_default false;
       let dyn = if dyn then Some true else None in
       Run_main.main ~pp_results ?dyn ~j ?timeout ?memory ?csv ~provers
-        ~meta ?task ?summary ?dir_file ?proof_dir ?output ~save ~wal_mode defs paths ()
+        ~meta ?task ?summary ?dir_file ?proof_dir ?output ~save ~wal_mode
+        ~desktop_notification ~no_failure ~update defs paths ()
     in
     let defs = Bin_utils.definitions_term
     and dyn =
       Arg.(value & flag & info ["progress"] ~doc:"print progress bar")
     and pp_results =
       Arg.(value & opt bool true & info ["pp-results"] ~doc:"print results as they are found")
-    and output = 
+    and output =
       Arg.(value & opt (some string) None & info ["o"; "output"] ~doc:"output database file")
     and save =
       Arg.(value & opt bool true & info ["save"] ~doc:"save results on disk")
@@ -63,11 +65,18 @@ module Run = struct
       Arg.(value & flag & info ["no-color"; "nc"] ~doc:"disable colored output")
     and summary =
       Arg.(value & opt (some string) None & info ["summary"] ~doc:"write summary in FILE")
+    and desktop_notification =
+      Arg.(value & opt bool true & info ["desktop-notification"; "dn"] ~doc:"send a desktop notification when the benchmarking is done (true by default)")
+    and no_failure =
+      Arg.(value & flag & info ["no-failure"; "nf"] ~doc:"don't fail if some provers give incorrect answers (contradictory to what was expected)")
+    and update =
+      Arg.(value & flag & info ["update"; "u"] ~doc:"if the output file already exists, overwrite it with the new one.")
     in
     Cmd.v (Cmd.info ~doc "run")
       (Term.(const aux $ j $ pp_results $ dyn $ paths
              $ dir_file $ proof_dir $ defs $ task $ timeout $ memory
-             $ meta $ provers $ csv $ summary $ no_color $ output $ save $ wal_mode))
+             $ meta $ provers $ csv $ summary $ no_color $ output $ save $ wal_mode
+             $ desktop_notification $ no_failure $ update))
 end
 
 module List_files = struct

--- a/src/core/Bin_utils.ml
+++ b/src/core/Bin_utils.ml
@@ -67,7 +67,7 @@ let dump_summary ~summary results : unit =
            Format.fprintf out "%a@." Test_top_result.pp_compact results);
   end
 
-let check_res_an notify a : unit =
+let check_res_an ?(no_failure = false) notify a : unit =
   if List.for_all (fun (_,r) -> Test_analyze.is_ok r) a
   then (
     Notify.send notify "OK";
@@ -76,15 +76,15 @@ let check_res_an notify a : unit =
       List.fold_left (fun n (_,r) -> n + Test_analyze.num_bad r) 0 a
     in
     Notify.sendf notify "FAIL (%d failures)" n_fail;
-    Error.failf "FAIL (%d failures)" n_fail
+    if not no_failure then Error.failf "FAIL (%d failures)" n_fail
   )
 
-let check_compact_res notify (results:Test_compact_result.t) : unit =
-  check_res_an notify (results.Test_compact_result.cr_analyze)
+let check_compact_res ?(no_failure = false) notify (results:Test_compact_result.t) : unit =
+  check_res_an ~no_failure notify (results.Test_compact_result.cr_analyze)
 
-let check_res notify (results:Test_top_result.t) : unit =
+let check_res ?(no_failure = false) notify (results:Test_top_result.t) : unit =
   let a = Test_top_result.analyze results in
-  check_res_an notify a
+  check_res_an ~no_failure notify a
 
 let printbox_stat st : unit =
   let box_st = Test_stat.to_printbox_l st in

--- a/src/core/Exec_action.mli
+++ b/src/core/Exec_action.mli
@@ -34,6 +34,7 @@ module Exec_run_provers : sig
     ?on_done:(Test_compact_result.t -> unit) ->
     ?interrupted:(unit -> bool) ->
     ?output:string ->
+    ?update:bool ->
     uuid:Uuidm.t ->
     save:bool ->
     wal_mode:bool ->


### PR DESCRIPTION
I've noticed that benchpress gets stuck when it tries to send a desktop notification when it is run on a server, settings `--desktop-notification` to false avoids that.
`--no-failure` makes it not fail when there are unsound answers,  it just prints the results.
`--update` makes it not fail when the given output file already exists, in case you want benchpress to overwrite.