### PR TITLE
Running benchpress on a slurm-managed cluster

### DIFF
--- a/benchpress-worker.opam
+++ b/benchpress-worker.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "0.1"
-authors: ["Simon Cruanes" "Guillaume Bury"]
+authors: ["Simon Cruanes" "Guillaume Bury" "Hichem Rami Ait El Hara"]
 synopsis: "A benchpress helper worker"
 maintainer: "simon.cruanes.2007@m4x.org"
 build: [

--- a/benchpress-worker.opam
+++ b/benchpress-worker.opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+version: "0.1"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+synopsis: "A benchpress helper worker"
+maintainer: "simon.cruanes.2007@m4x.org"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.08" }
+  "dune" { >= "1.11" }
+  "containers" { >= "3.0" & < "4.0" }
+  "benchpress" { = version }
+  "cmdliner" {>= "1.1.0"}
+]
+homepage: "https://github.com/sneeuwballen/benchpress/"
+dev-repo: "git+https://github.com/sneeuwballen/benchpress.git"
+bug-reports: "https://github.com/sneeuwballen/benchpress/issues"

--- a/src/bin/Run_main.ml
+++ b/src/bin/Run_main.ml
@@ -11,7 +11,8 @@ let execute_run_prover_action ?j ?timestamp ?pp_results ?dyn ?limits ?proof_dir
   @@ fun () ->
   let interrupted = CCLock.create false in
   let r =
-    Exec_action.Exec_run_provers.expand ?dyn ?j ?proof_dir ?limits defs r
+    Exec_action.Exec_run_provers.expand ?dyn ?j ?proof_dir ?limits defs r.limits
+      r.j r.pattern r.dirs r.provers
   in
   let len = List.length r.problems in
   Notify.sendf notify "testing with %d provers, %d problems…"
@@ -30,13 +31,47 @@ let execute_run_prover_action ?j ?timestamp ?pp_results ?dyn ?limits ?proof_dir
   in
   result
 
+let execute_submit_job_action ?pp_results ?j ?timestamp ?dyn ?limits ?proof_dir
+    ?output ~notify ~(uuid : Uuidm.t) ~(save : bool) ~wal_mode ~update
+    (defs : Definitions.t) (r : Action.run_provers_slurm_submission) :
+    _ * Test_compact_result.t =
+  Error.guard
+    (Error.wrapf "run provers with slurm action@ `@[%a@]`" Action.pp_run_provers_slurm
+       r)
+  @@ fun () ->
+  let interrupted = CCLock.create false in
+  let exp_r =
+    Exec_action.Exec_run_provers.expand ~slurm:true ?dyn ?j ?proof_dir ?limits
+      defs r.limits r.j r.pattern r.dirs r.provers
+  in
+  let len = List.length exp_r.problems in
+  Notify.sendf notify "testing with %d provers, %d problems…"
+    (List.length r.provers) len;
+  let progress = Exec_action.Progress_run_provers.make ?pp_results ?dyn exp_r in
+  (* submit job *)
+  let result =
+    Error.guard (Error.wrapf "running %d tests" len) @@ fun () ->
+    Exec_action.Exec_run_provers.run_sbatch_job ~uuid ?timestamp
+      ~interrupted:(fun () -> CCLock.get interrupted)
+      ?partition:r.partition ~nodes:r.nodes ~addr:r.addr ~port:r.port
+      ~ntasks:r.ntasks ~save ~wal_mode ~on_solve:progress#on_res
+      ~on_start_proof_check:(fun () -> progress#on_start_proof_check)
+      ~on_proof_check:progress#on_proof_check_res
+      ~on_done:(fun _ -> progress#on_done)
+      exp_r ?output ~update
+  in
+  result
+
 type top_task =
   | TT_run_provers of Action.run_provers * Definitions.t
   | TT_other of Action.t
+  | TT_run_slurm_submission of
+      Action.run_provers_slurm_submission * Definitions.t
 
 let main ?j ?pp_results ?dyn ?timeout ?memory ?csv ?(provers = []) ?meta:_
     ?summary ?task ?dir_file ?proof_dir ?output ?(save = true)
     ?(wal_mode = false) ~desktop_notification ~no_failure ~update
+    ?(sbatch = false) ?partition ?nodes ?addr ?port ?ntasks
     (defs : Definitions.t) paths () : unit =
   Log.info (fun k ->
       k "run-main.main for paths %a" (Misc.pp_list Misc.Pp.pp_str) paths);
@@ -56,6 +91,39 @@ let main ?j ?pp_results ?dyn ?timeout ?memory ?csv ?(provers = []) ?meta:_
     | Some task_name ->
       let t = Definitions.find_task defs task_name in
       (match t with
+      | { view = { Task.action = Action.Act_run_provers r; _ }; loc }
+        when sbatch ->
+        Log.warn (fun k ->
+            k "Calling benchpress in slurm mode on a normal run task!");
+        Error.guard (Error.wrap ~loc "running task 'run provers with slurm'")
+        @@ fun () ->
+        let j = CCOpt.( <+> ) j r.j in
+        let timeout =
+          CCOpt.( <+> ) timeout
+            (CCOpt.map_or ~default:None
+               (fun t -> Some (Limit.Time.as_int Seconds t))
+               r.limits.time)
+        in
+        let memory =
+          CCOpt.( <+> ) memory
+            (CCOpt.map_or ~default:None
+               (fun t -> Some (Limit.Memory.as_int Megabytes t))
+               r.limits.memory)
+        in
+        let r =
+          Definitions.mk_run_provers_slurm_submission ?partition ?nodes ?j ?addr
+            ?port ?ntasks ~paths ?timeout ?memory ~provers ?loc:r.loc defs
+        in
+        let r =
+          {
+            r with
+            provers =
+              r.provers @ r.provers
+              |> CCList.sort_uniq ~cmp:Prover.compare_by_name;
+            dirs = r.dirs @ r.dirs;
+          }
+        in
+        TT_run_slurm_submission (r, defs)
       | { view = { Task.action = Action.Act_run_provers r; _ }; loc } ->
         Error.guard (Error.wrap ~loc "running task 'run provers'") @@ fun () ->
         (* convert paths and provers *)
@@ -66,7 +134,41 @@ let main ?j ?pp_results ?dyn ?timeout ?memory ?csv ?(provers = []) ?meta:_
         in
         let r = { r with provers; dirs = paths @ r.dirs } in
         TT_run_provers (r, defs)
+      | { view = { Task.action = Action.Act_run_slurm_submission r; _ }; loc }
+        ->
+        Error.guard (Error.wrap ~loc "running task 'run provers with slurm'")
+        @@ fun () ->
+        let r =
+          {
+            r with
+            nodes = CCOpt.value ~default:r.nodes nodes;
+            j = CCOpt.( <+> ) j r.j;
+            limits =
+              {
+                r.limits with
+                time =
+                  CCOpt.map_or ~default:r.limits.time
+                    (fun s -> Some (Limit.Time.mk ~s ()))
+                    timeout;
+                memory =
+                  CCOpt.map_or ~default:r.limits.memory
+                    (fun m -> Some (Limit.Memory.mk ~m ()))
+                    memory;
+              };
+            provers =
+              CCList.map (Definitions.find_prover' defs) provers @ r.provers
+              |> CCList.sort_uniq ~cmp:Prover.compare_by_name;
+            dirs = CCList.map (Definitions.mk_subdir defs) paths @ r.dirs;
+          }
+        in
+        TT_run_slurm_submission (r, defs)
       | { loc = _; view = t } -> TT_other t.action)
+    | None when sbatch ->
+      let r : Action.run_provers_slurm_submission =
+        Definitions.mk_run_provers_slurm_submission ?partition ?nodes ?j ?addr
+          ?port ?ntasks ~paths ?timeout ?memory ~provers defs
+      in
+      TT_run_slurm_submission (r, defs)
     | None ->
       let provers =
         match provers with
@@ -103,7 +205,38 @@ let main ?j ?pp_results ?dyn ?timeout ?memory ?csv ?(provers = []) ?meta:_
       let res = Lazy.force top_res in
       Bin_utils.dump_summary ~summary res
     );
-    (* now fail if results were bad *)
+    let r = Bin_utils.check_compact_res ~no_failure notify results in
+    Notify.sync notify;
+    Bin_utils.printbox_compact_results results;
+    (* try to send a desktop notification *)
+    if desktop_notification then (
+      try
+        CCUnix.call "notify-send 'benchmark done (%s)'"
+          (CCOpt.map_or ~default:"?" Misc.human_duration
+             results.cr_meta.total_wall_time)
+        |> ignore
+      with _ -> ()
+    );
+    r
+  | TT_run_slurm_submission (run_provers_action_sbatch, defs) ->
+    let j = CCOpt.Infix.(j <+> Definitions.option_j defs) in
+    let progress = CCOpt.Infix.(dyn <+> Definitions.option_progress defs) in
+    let limits = run_provers_action_sbatch.limits in
+    let uuid = Misc.mk_uuid () in
+
+    let top_res, (results : Test_compact_result.t) =
+      execute_submit_job_action ?pp_results ~uuid ?proof_dir ?dyn:progress
+        ~limits ?j ?output ~notify ~timestamp ~save ~wal_mode ~update defs
+        run_provers_action_sbatch
+    in
+    if CCOpt.is_some csv then (
+      let res = Lazy.force top_res in
+      Bin_utils.dump_csv ~csv res
+    );
+    if CCOpt.is_some summary then (
+      let res = Lazy.force top_res in
+      Bin_utils.dump_summary ~summary res
+    );
     let r = Bin_utils.check_compact_res ~no_failure notify results in
     Notify.sync notify;
     Bin_utils.printbox_compact_results results;

--- a/src/core/Action.ml
+++ b/src/core/Action.ml
@@ -14,6 +14,30 @@ type run_provers = {
   loc: Loc.t option;
 }
 
+type run_provers_slurm_submission = {
+  partition: string option;
+  (* The partition to which the allocated nodes should belong. *)
+  nodes: int;
+  (* the maximum number of nodes that can be allocated for the job.
+     One worker will run per node *)
+  addr: Unix.inet_addr;
+  (* IP address of the server on the control node.
+     Needs to be reachable by the workers which will run on the allocated calculation nodes. *)
+  port: int;
+  (* port of the server in the control node. *)
+  j: int option;
+  (* number of parallel threads that will be launched by the workers.
+     Default is the number of processors on the node. *)
+  ntasks: int;
+  (* The number of tasks to give the workers at a time.
+     Default is equal to the number of threads. *)
+  dirs: Subdir.t list; (* list of problems *)
+  provers: Prover.t list;
+  pattern: string option;
+  limits: Limit.All.t;
+  loc: Loc.t option;
+}
+
 type git_fetch_action = Git_fetch | Git_pull
 
 type git_checkout = {
@@ -26,13 +50,14 @@ type git_checkout = {
 (** An action to perform *)
 type t =
   | Act_run_provers of run_provers
+  | Act_run_slurm_submission of run_provers_slurm_submission
   | Act_git_checkout of git_checkout
   | Act_run_cmd of { cmd: string; loc: Loc.t }
   | Act_progn of t list
 
 let pp_run_provers out (self : run_provers) =
   let open Misc.Pp in
-  let { dirs; provers; limits; j; pattern; loc = _ } = self in
+  let ({ dirs; provers; limits; j; pattern; loc = _ } : run_provers) = self in
   Fmt.fprintf out "(@[<v1>run_provers%a%a%a%a%a%a%a@])"
     (pp_f "dirs" (pp_l Subdir.pp))
     dirs
@@ -46,6 +71,42 @@ let pp_run_provers out (self : run_provers) =
     limits.memory
     (pp_opt "stack" Limit.Stack.pp)
     limits.stack (pp_opt "j" Fmt.int) j
+
+let pp_run_provers_slurm out (self : run_provers_slurm_submission) =
+  let open Misc.Pp in
+  let {
+    partition;
+    nodes;
+    j;
+    dirs;
+    provers;
+    pattern;
+    limits;
+    addr;
+    port;
+    ntasks;
+    loc = _;
+  } =
+    self
+  in
+  Fmt.fprintf out "(@[<v1>run_provers.Slurm%a%a%a%a%a%a%a%a%a%a%a%a@])"
+    (pp_opt "partition" Fmt.string)
+    partition (pp_f "nodes" Fmt.int) nodes
+    (pp_f "addr" Misc.pp_inet_addr)
+    addr (pp_f "port" Fmt.int) port (pp_f "ntasks" Fmt.int) ntasks
+    (pp_opt "j" Fmt.int) j
+    (pp_f "dirs" (pp_l Subdir.pp))
+    dirs
+    (pp_f "provers" (pp_l Prover.pp_name))
+    provers
+    (pp_opt "pattern" pp_regex)
+    pattern
+    (pp_opt "timeout" Limit.Time.pp)
+    limits.time
+    (pp_opt "memory" Limit.Memory.pp)
+    limits.memory
+    (pp_opt "stack" Limit.Stack.pp)
+    limits.stack
 
 let pp_git_fetch out = function
   | Git_fetch -> Fmt.string out "fetch"
@@ -62,6 +123,7 @@ let pp_git_checkout out (self : git_checkout) =
 let rec pp out (self : t) : unit =
   match self with
   | Act_run_provers a -> pp_run_provers out a
+  | Act_run_slurm_submission a -> pp_run_provers_slurm out a
   | Act_git_checkout g -> pp_git_checkout out g
   | Act_run_cmd { cmd = s; loc = _ } -> Fmt.fprintf out "(run-cmd %S)" s
   | Act_progn l -> Fmt.fprintf out "(@[%a@])" (Misc.Pp.pp_l pp) l

--- a/src/core/Definitions.mli
+++ b/src/core/Definitions.mli
@@ -58,6 +58,23 @@ val mk_run_provers :
     All the provers must be defined, and the paths must be contained
     in declared [dir]. *)
 
+val mk_run_provers_slurm_submission :
+  ?j:int ->
+  paths:path list ->
+  ?timeout:int ->
+  ?memory:int ->
+  ?stack:Stanza.stack_limit ->
+  ?pattern:path ->
+  provers:path list ->
+  ?loc:Loc.t ->
+  ?partition:path ->
+  ?nodes:int ->
+  ?addr:Unix.inet_addr ->
+  ?port:int ->
+  ?ntasks:int ->
+  t ->
+  Action.run_provers_slurm_submission
+
 val completions : t -> ?before_pos:Loc.pos -> string -> def list
 (** Find possible completions *)
 

--- a/src/core/Exec_action.ml
+++ b/src/core/Exec_action.ml
@@ -3,19 +3,6 @@
 open Common
 module Log = (val Logs.src_log (Logs.Src.create "benchpress.runexec-action"))
 
-(** File for results with given uuid and timestamp *)
-let db_file_for_uuid ~timestamp (uuid : Uuidm.t) : string =
-  let filename =
-    Printf.sprintf "res-%s-%s.sqlite"
-      (match Ptime.of_float_s timestamp with
-      | None -> Printf.sprintf "<time %.1fs>" timestamp
-      | Some t -> Misc.datetime_compact t)
-      (Uuidm.to_string uuid)
-  in
-  let data_dir = Filename.concat (Xdg.data_dir ()) !Xdg.name_of_project in
-  (try Unix.mkdir data_dir 0o744 with _ -> ());
-  Filename.concat data_dir filename
-
 module Exec_run_provers : sig
   type t = Action.run_provers
 
@@ -29,13 +16,18 @@ module Exec_run_provers : sig
   }
 
   val expand :
+    ?slurm:bool ->
     ?j:int ->
     ?dyn:bool ->
     ?limits:Limit.All.t ->
     ?proof_dir:string ->
     ?interrupted:(unit -> bool) ->
     Definitions.t ->
-    t ->
+    Limit.All.t ->
+    int option ->
+    string option ->
+    Subdir.t list ->
+    Prover.t list ->
     expanded
 
   val run :
@@ -58,6 +50,27 @@ module Exec_run_provers : sig
         @param on_solve called whenever a single problem is solved
         @param on_done called when the whole process is done
     *)
+
+  val run_sbatch_job :
+    ?timestamp:float ->
+    ?on_start:(expanded -> unit) ->
+    ?on_solve:(Test.result -> unit) ->
+    ?on_start_proof_check:(unit -> unit) ->
+    ?on_proof_check:(Test.proof_check_result -> unit) ->
+    ?on_done:(Test_compact_result.t -> unit) ->
+    ?interrupted:(unit -> bool) ->
+    ?partition:string ->
+    nodes:int ->
+    addr:Unix.inet_addr ->
+    port:int ->
+    ntasks:int ->
+    ?output:string ->
+    ?update:bool ->
+    uuid:Uuidm.t ->
+    save:bool ->
+    wal_mode:bool ->
+    expanded ->
+    Test_top_result.t lazy_t * Test_compact_result.t
 end = struct
   type t = Action.run_provers
 
@@ -123,18 +136,26 @@ end = struct
     | exn -> Error.(raise @@ of_exn exn)
 
   (* Expand options into concrete choices *)
-  let expand ?j ?(dyn = false) ?limits ?proof_dir ?interrupted
-      (defs : Definitions.t) (self : t) : expanded =
+  let expand ?(slurm = false) ?j ?(dyn = false) ?limits ?proof_dir ?interrupted
+      (defs : Definitions.t) s_limits s_j s_pattern s_dirs s_provers : expanded
+      =
     let limits =
       match limits with
-      | None -> self.limits
-      | Some l -> Limit.All.with_defaults l ~defaults:self.limits
+      | None -> s_limits
+      | Some l -> Limit.All.with_defaults l ~defaults:s_limits
     in
-    let j = j >?? self.j >? Misc.guess_cpu_count () in
+    let j =
+      j >?? s_j
+      >?
+      if slurm then
+        0
+      else
+        Misc.guess_cpu_count ()
+    in
     let problems =
       CCList.flat_map
-        (expand_subdir ?pattern:self.pattern ~dyn ?interrupted)
-        self.dirs
+        (expand_subdir ?pattern:s_pattern ~dyn ?interrupted)
+        s_dirs
     in
     let checkers =
       Definitions.all_checkers defs
@@ -143,7 +164,7 @@ end = struct
              c.Proof_checker.name, c)
       |> Misc.Str_map.of_list
     in
-    { j; limits; problems; checkers; proof_dir; provers = self.provers }
+    { j; limits; problems; checkers; proof_dir; provers = s_provers }
 
   let _nop _ = ()
 
@@ -161,12 +182,7 @@ end = struct
       CCFun.finally ~h:(fun () -> try Sys.remove file with _ -> ()) ~f
     | _ -> f ()
 
-  let run ?(timestamp = Misc.now_s ()) ?(on_start = _nop) ?(on_solve = _nop)
-      ?(on_start_proof_check = _nop) ?(on_proof_check = _nop) ?(on_done = _nop)
-      ?(interrupted = fun _ -> false) ?output ?(update = false) ~uuid ~save
-      ~wal_mode (self : expanded) : _ * _ =
-    let start = Misc.now_s () in
-    (* prepare DB *)
+  let prepare_db ~wal_mode ?output ~update timestamp uuid save provers =
     let db =
       if save then (
         let db_file =
@@ -180,7 +196,7 @@ end = struct
                 Error.failf "The file %s exists" output
             else
               output
-          | None -> db_file_for_uuid ~timestamp uuid
+          | None -> Misc.file_for_uuid "res" ~timestamp uuid "sqlite"
         in
         Log.debug (fun k -> k "output database file %s" db_file);
         let db = Sqlite3.db_open ~mutex:`FULL db_file in
@@ -213,7 +229,18 @@ end = struct
         provers = [];
       };
     ( Error.guard (Error.wrap "inserting provers into DB") @@ fun () ->
-      List.iter (Prover.to_db db) self.provers );
+      List.iter (Prover.to_db db) provers );
+    db
+
+  let run ?(timestamp = Misc.now_s ()) ?(on_start = _nop) ?(on_solve = _nop)
+      ?(on_start_proof_check = _nop) ?(on_proof_check = _nop) ?(on_done = _nop)
+      ?(interrupted = fun _ -> false) ?output ?(update = false) ~uuid ~save
+      ~wal_mode (self : expanded) : _ * _ =
+    let start = Misc.now_s () in
+    (* prepare DB *)
+    let db =
+      prepare_db ~wal_mode ?output ~update timestamp uuid save self.provers
+    in
     on_start self;
 
     CCOpt.iter Misc.mkdir_rec self.proof_dir;
@@ -337,6 +364,265 @@ end = struct
          Test_top_result.make ~analyze_full:true ~meta ~provers res_l)
     in
     let r = Test_compact_result.of_db ~full:true db in
+    on_done r;
+    Logs.debug (fun k -> k "closing db…");
+    ignore (Sqlite3.db_close db : bool);
+    top_res, r
+
+  let run_sbatch_job ?(timestamp = Misc.now_s ()) ?(on_start = _nop)
+      ?(on_solve = _nop) ?(on_start_proof_check = _nop) ?(on_proof_check = _nop)
+      ?(on_done = _nop) ?(interrupted = fun _ -> false) ?partition ~nodes ~addr
+      ~port ~ntasks ?output ?(update = false) ~uuid ~save ~wal_mode
+      (self : expanded) : _ * _ =
+    ignore on_start_proof_check;
+    let start = Misc.now_s () in
+    let db =
+      prepare_db ~wal_mode ?output ~update timestamp uuid save self.provers
+    in
+    on_start self;
+    let jobs =
+      CCList.flat_map
+        (fun pb ->
+          CCList.map (fun prover -> prover.Prover.name, pb) self.provers)
+        self.problems
+    in
+    let config_file = Misc.file_for_uuid "config" ~timestamp uuid "sexp" in
+    let sexps =
+      Misc.Str_map.fold
+        (fun _ c acc ->
+          Stanza.proof_checker_wl_to_st (With_loc.make ~loc:Loc.none c) :: acc)
+        self.checkers
+        (List.fold_left
+           (fun acc p ->
+             Stanza.prover_wl_to_st (With_loc.make ~loc:Loc.none p) :: acc)
+           [] self.provers)
+    in
+    CCIO.with_out config_file (fun oc ->
+        let ocf = Format.formatter_of_out_channel oc in
+        List.iter (Format.fprintf ocf "%a@." Stanza.pp) (List.rev sexps));
+
+    let get_tasks =
+      let jobs_ref = ref jobs in
+      let jobs_lock = Mutex.create () in
+      fun j ->
+        Mutex.lock jobs_lock;
+        let rec aux j acc jobs =
+          match jobs with
+          | _ when j <= 0 -> acc, jobs
+          | h :: t -> aux (j - 1) (h :: acc) t
+          | [] -> acc, []
+        in
+        let tasks, jobs = aux j [] !jobs_ref in
+        jobs_ref := jobs;
+        Mutex.unlock jobs_lock;
+        tasks
+    in
+    let add_resps, get_resps, get_nb_resps =
+      let nb_resps = ref 0 in
+      let resps_ref = ref [] in
+      let resps_lock = Mutex.create () in
+      let db_wl = CCLock.create db in
+      let add_resps evl =
+        Mutex.lock resps_lock;
+        nb_resps := !nb_resps + List.length evl;
+        resps_ref := List.rev_append evl !resps_ref;
+        List.iter
+          (fun ev ->
+            (match ev with
+            | Run_event.Prover_run r -> on_solve r
+            | Checker_run r -> on_proof_check r);
+            CCLock.with_lock db_wl (fun db -> Run_event.to_db db ev))
+          evl;
+        Mutex.unlock resps_lock
+      in
+      let get_resps () =
+        Mutex.lock resps_lock;
+        let res = !resps_ref in
+        Mutex.unlock resps_lock;
+        res
+      in
+      let get_nb_resps () =
+        Mutex.lock resps_lock;
+        let res = List.length !resps_ref in
+        Mutex.unlock resps_lock;
+        res
+      in
+      add_resps, get_resps, get_nb_resps
+    in
+    let wdms_set_true, get_wdms =
+      let work_done_msg_sent = ref false in
+      let work_done_msg_sent_mutex = Mutex.create () in
+      let wdms_set_true () =
+        Mutex.lock work_done_msg_sent_mutex;
+        work_done_msg_sent := true;
+        Mutex.unlock work_done_msg_sent_mutex
+      in
+      let get_wdms () =
+        Mutex.lock work_done_msg_sent_mutex;
+        let res = !work_done_msg_sent in
+        Mutex.unlock work_done_msg_sent_mutex;
+        res
+      in
+      wdms_set_true, get_wdms
+    in
+    let incr_nb_workers, decr_nb_workers, get_nb_workers =
+      let nb_workers = ref 0 in
+      let nb_workers_mutex = Mutex.create () in
+      let aux f () =
+        Mutex.lock nb_workers_mutex;
+        f nb_workers;
+        Mutex.unlock nb_workers_mutex
+      in
+      ( aux incr,
+        aux decr,
+        fun () ->
+          Mutex.lock nb_workers_mutex;
+          let res = !nb_workers in
+          Mutex.unlock nb_workers_mutex;
+          res )
+    in
+    let nb_jobs = List.length jobs in
+
+    let resp_sock_path =
+      Misc.file_for_uuid "benchpress" ~dir:Xdg.runtime_dir ~timestamp uuid
+        "sock"
+    in
+    let resp_sock_addr = Unix.ADDR_UNIX resp_sock_path in
+
+    let server_loop ic oc =
+      Log.debug (fun k -> k "(@[server_loop@ : started.@])");
+      incr_nb_workers ();
+      try
+        while true do
+          match Marshal.from_channel ic with
+          | Msg.Worker_response (id, evl) ->
+            Log.debug (fun k ->
+                k "(@[server_loop@ : Worker %d sent %d responses.@])" id
+                  (List.length evl));
+            if evl <> [] then add_resps evl;
+            let tasks = get_tasks ntasks in
+            if tasks = [] then (
+              Marshal.to_channel oc Msg.Stop_worker [];
+              flush oc;
+              Log.debug (fun k ->
+                  k
+                    "(@[server_loop@ : Sent \"Stop_worker\" to Worker %d. No \
+                     more tasks left.@])"
+                    id)
+            ) else (
+              Marshal.to_channel oc (Msg.Worker_task tasks) [];
+              flush oc;
+              Log.debug (fun k ->
+                  k "(@[server_loop@ : Sent %d tasks to Worker %d@])"
+                    (List.length tasks) id)
+            )
+          | Msg.Worker_failure (id, e) ->
+            Log.err (fun k -> k "(@[server_loop@ : Worker %d failed!@])" id);
+            raise e
+        done
+      with
+      | End_of_file ->
+        Log.debug (fun k ->
+            k "(@[server_loop@ : Worker closed the connection.@])");
+        close_out oc;
+        decr_nb_workers ();
+        if
+          get_nb_workers () = 0
+          && get_nb_resps () = nb_jobs
+          && not (get_wdms ())
+        then (
+          wdms_set_true ();
+          let _, oc =
+            Unix.handle_unix_error Unix.open_connection resp_sock_addr
+          in
+          Marshal.to_channel oc Msg.Work_done [];
+          flush oc;
+          Log.debug (fun k ->
+              k "(@[server_loop@ : Sent \"Work_done\" to parent proc.@])");
+          close_out oc
+        )
+      | e ->
+        Log.err (fun k -> k "(@[server_loop@ : Worker failed!@])");
+        close_out oc;
+        decr_nb_workers ();
+        raise e
+    in
+
+    let sock, used_port = Misc.mk_socket (Unix.ADDR_INET (addr, port)) in
+    ignore (CCThread.spawn (fun () -> Misc.start_server nodes server_loop sock));
+
+    Log.debug (fun k ->
+        k "Spawned the thread that establishes a server listening at: %s:%s."
+          (Unix.string_of_inet_addr addr)
+          used_port);
+    let sbatch_cmds =
+      Slurm_cmd.mk_sbatch_cmds self.limits self.proof_dir self.j addr used_port
+        partition config_file nodes
+    in
+    let job_ids =
+      List.fold_left
+        (fun acc cmd ->
+          let rpres = Run_proc.run cmd in
+          let job_id = int_of_string (String.trim rpres.stdout) in
+          Log.debug (fun k -> k "Submitted the job %d to slurm@." job_id);
+          job_id :: acc)
+        [] sbatch_cmds
+    in
+    Log.debug (fun k ->
+        k "Submitted %d launch worker scripts to slurm." (List.length job_ids));
+    Log.debug (fun k -> k "Waiting for the \"Work_done\" message.");
+    Misc.establish_server 1
+      (fun ic _ ->
+        match Marshal.from_channel ic with
+        | Msg.Work_done -> ())
+      resp_sock_addr;
+    Log.debug (fun k -> k "Received the \"Work_done\" message.");
+
+    List.iter
+      (fun job_id -> ignore (Sys.command (Slurm_cmd.scancel job_id)))
+      job_ids;
+    Log.debug (fun k ->
+        k "Killed the workers that are still alive or didn't start yet.");
+
+    Sys.remove config_file;
+    Sys.remove resp_sock_path;
+    Log.debug (fun k ->
+        k "Deleted the generated config_file and linux socket file.");
+
+    if interrupted () then Error.fail "run.interrupted";
+    let total_wall_time = Misc.now_s () -. start in
+    let uuid = uuid in
+    Logs.info (fun k ->
+        k "benchmark done in %a, uuid=%a" Misc.pp_human_duration total_wall_time
+          Uuidm.pp uuid);
+    let timestamp = Some timestamp in
+    let total_wall_time = Some total_wall_time in
+    let meta =
+      {
+        Test_metadata.uuid;
+        timestamp;
+        total_wall_time;
+        n_results = 0;
+        dirs = [];
+        n_bad = 0;
+        provers = List.map Prover.name self.provers;
+      }
+    in
+    Logs.debug (fun k -> k "saving metadata…");
+    Test_metadata.to_db db meta;
+    let top_res =
+      lazy
+        (let provers_map =
+           List.fold_left
+             (fun m ({ Prover.name; _ } as p) -> Misc.Str_map.add name p m)
+             Misc.Str_map.empty self.provers
+         in
+         let provers =
+           List.map (fun (pn, _) -> Misc.Str_map.find pn provers_map) jobs
+         in
+         Test_top_result.make ~analyze_full:true ~meta ~provers (get_resps ()))
+    in
+    let r = Test_compact_result.of_db db in
     on_done r;
     Logs.debug (fun k -> k "closing db…");
     ignore (Sqlite3.db_close db : bool);
@@ -552,7 +838,7 @@ let rec run ?output ?(save = true) ?interrupted ?cb_progress
     let r_expanded =
       Exec_run_provers.expand ?interrupted ~dyn:is_dyn
         ?j:(Definitions.option_j defs)
-        defs r
+        defs r.limits r.j r.pattern r.dirs r.provers
     in
     let progress =
       Progress_run_provers.make ~pp_results:true ~dyn:is_dyn ?cb_progress
@@ -565,6 +851,42 @@ let rec run ?output ?(save = true) ?interrupted ?cb_progress
         ~on_done:(fun _ -> progress#on_done)
         ?output ~save ~wal_mode:false ~timestamp:(Misc.now_s ()) ~uuid
         r_expanded
+    in
+    Format.printf "task done: %a@." Test_compact_result.pp res;
+    ()
+  | Act_run_slurm_submission
+      {
+        nodes;
+        j;
+        dirs;
+        provers;
+        pattern;
+        limits;
+        partition;
+        addr;
+        port;
+        ntasks;
+        _;
+      } ->
+    let is_dyn =
+      CCOpt.get_or ~default:false @@ Definitions.option_progress defs
+    in
+    let r_expanded =
+      Exec_run_provers.expand ~slurm:true ?interrupted ~dyn:is_dyn
+        ?j:(Definitions.option_j defs)
+        defs limits j pattern dirs provers
+    in
+    let progress =
+      Progress_run_provers.make ~pp_results:true ~dyn:is_dyn ?cb_progress
+        r_expanded
+    in
+    let uuid = Misc.mk_uuid () in
+    let res =
+      Exec_run_provers.run_sbatch_job ~timestamp:(Misc.now_s ()) ?interrupted
+        ~on_solve:progress#on_res ~on_proof_check:progress#on_proof_check_res
+        ~on_done:(fun _ -> progress#on_done)
+        ?output ~save ~uuid ~wal_mode:false ?partition ~ntasks ~nodes ~addr
+        ~port r_expanded
     in
     Format.printf "task done: %a@." Test_compact_result.pp res;
     ()

--- a/src/core/Exec_action.mli
+++ b/src/core/Exec_action.mli
@@ -15,13 +15,18 @@ module Exec_run_provers : sig
   }
 
   val expand :
+    ?slurm:bool ->
     ?j:int ->
     ?dyn:bool ->
     ?limits:Limit.All.t ->
     ?proof_dir:string ->
     ?interrupted:(unit -> bool) ->
     Definitions.t ->
-    t ->
+    Limit.All.t ->
+    int option ->
+    string option ->
+    Subdir.t list ->
+    Prover.t list ->
     expanded
 
   val run :
@@ -44,6 +49,27 @@ module Exec_run_provers : sig
         @param on_solve called whenever a single problem is solved
         @param on_done called when the whole process is done
     *)
+
+  val run_sbatch_job :
+    ?timestamp:float ->
+    ?on_start:(expanded -> unit) ->
+    ?on_solve:(Test.result -> unit) ->
+    ?on_start_proof_check:(unit -> unit) ->
+    ?on_proof_check:(Test.proof_check_result -> unit) ->
+    ?on_done:(Test_compact_result.t -> unit) ->
+    ?interrupted:(unit -> bool) ->
+    ?partition:string ->
+    nodes:int ->
+    addr:Unix.inet_addr ->
+    port:int ->
+    ntasks:int ->
+    ?output:string ->
+    ?update:bool ->
+    uuid:Uuidm.t ->
+    save:bool ->
+    wal_mode:bool ->
+    expanded ->
+    Test_top_result.t lazy_t * Test_compact_result.t
 end
 
 module Progress_run_provers : sig

--- a/src/core/Misc.ml
+++ b/src/core/Misc.ml
@@ -240,6 +240,20 @@ let rec mkdir_rec (d : string) =
     with _ -> Logs.debug (fun k -> k "mkdir %S failed" d)
   )
 
+(** [file_for_uuid pref ?dir ~timestamp uuid ext] builds a filename of the form
+    "[pref]-[timestamp]-[uuid].[ext]" *)
+let file_for_uuid pref ?(dir = Xdg.data_dir) ~timestamp uuid ext =
+  let filename =
+    Printf.sprintf "%s-%s-%s.%s" pref
+      (match Ptime.of_float_s timestamp with
+      | None -> Printf.sprintf "<time %.1fs>" timestamp
+      | Some t -> datetime_compact t)
+      (Uuidm.to_string uuid) ext
+  in
+  let data_dir = Filename.concat (dir ()) !Xdg.name_of_project in
+  mkdir_rec data_dir;
+  Filename.concat data_dir filename
+
 (** concatenate list into a path *)
 let rec filename_concat_l = function
   | [] -> "."
@@ -364,3 +378,70 @@ module Json = struct
 
   let to_string (self : t) : string = Fmt.asprintf "%a" pp self
 end
+
+(** [mk_shell_cmd ?options ?target exec] makes a command that executes [exec] \
+    with the options [options] on the target [target]. *)
+let mk_shell_cmd ?(options = []) ?target exec =
+  let buf = Buffer.create 32 in
+  Buffer.add_string buf exec;
+  List.iter
+    (fun (k, v_opt) ->
+      Buffer.add_string buf
+        (match v_opt with
+        | Some v -> " " ^ k ^ " " ^ v
+        | None -> " " ^ k))
+    options;
+  CCOption.iter (fun s -> Buffer.add_string buf (" " ^ s)) target;
+  Buffer.contents buf
+
+let pp_inet_addr fmt a = Format.fprintf fmt "%s" (Unix.string_of_inet_addr a)
+
+let pp_unix_addr fmt addr =
+  match addr with
+  | Unix.ADDR_UNIX s -> Format.fprintf fmt "ADDR_UNIX %s" s
+  | Unix.ADDR_INET (addr, id) ->
+    Format.fprintf fmt "ADDR_INET (%a, %d)" pp_inet_addr addr id
+
+let ip_addr_conv =
+  Cmdliner.Arg.conv
+    ( (fun str ->
+        try Ok (Unix.inet_addr_of_string str) with Failure s -> Error (`Msg s)),
+      fun fmt addr -> Format.fprintf fmt "%s" (Unix.string_of_inet_addr addr) )
+
+let localhost_addr () =
+  (Unix.gethostbyname (Unix.gethostname ())).Unix.h_addr_list.(0)
+
+let rec accept_non_intr s =
+  try Unix.accept ~cloexec:true s
+  with Unix.Unix_error (EINTR, _, _) -> accept_non_intr s
+
+(** [mk_socket sockaddr] makes a socket, binds it to [sockaddr] and returns it
+    along with the name of the service if it is a unix socket or the port number
+    if it is an internet socket. *)
+let mk_socket sockaddr =
+  let open Unix in
+  let sock = socket ~cloexec:true (domain_of_sockaddr sockaddr) SOCK_STREAM 0 in
+  setsockopt sock SO_REUSEADDR true;
+  bind sock sockaddr;
+  sock, (Unix.getnameinfo (Unix.getsockname sock) []).ni_service
+
+(** [start_server n server_fun sock] starts a server on the socket [sock],
+    assumes that the socket is correcly bound to a valid address.
+    Allows up to [n] connections and runs the function [server_fun] for each
+    connection on a separate thread (uses threads, doesn't fork the process).*)
+let start_server n server_fun sock =
+  let open Unix in
+  listen sock 5;
+  CCThread.Arr.join
+  @@ CCThread.Arr.spawn n (fun _ ->
+         let s, _caller = accept_non_intr sock in
+         let inchan = in_channel_of_descr s in
+         let outchan = out_channel_of_descr s in
+         server_fun inchan outchan)
+
+(** [establish_server n server_fun sockaddr] same as
+    [Unix.establish_server], but it uses threads instead of forking the process
+    after each connection, and only accepts [n] connections  *)
+let establish_server n server_fun sockaddr =
+  let sock, _ = mk_socket sockaddr in
+  start_server n server_fun sock

--- a/src/core/Msg.ml
+++ b/src/core/Msg.ml
@@ -1,0 +1,9 @@
+type master_msg =
+  | Worker_task of (string * Problem.t) list (* prover name, problem *)
+  | Stop_worker
+
+type worker_msg =
+  | Worker_response of int * Run_event.t list
+  | Worker_failure of int * exn
+
+type th_msg = Work_done

--- a/src/core/Prover.ml
+++ b/src/core/Prover.ml
@@ -58,7 +58,7 @@ module Version = struct
   let pp out =
     let open Misc.Pp in
     function
-    | Tag s -> Fmt.fprintf out "(tag %a)" pp_str s
+    | Tag s -> Fmt.fprintf out "%a" pp_str s
     | Git { branch = b; commit = c } ->
       Fmt.fprintf out "(@[git@ branch=%a@ commit=%a@])" pp_str b pp_str c
 

--- a/src/core/Slurm_cmd.ml
+++ b/src/core/Slurm_cmd.ml
@@ -1,0 +1,69 @@
+(** [sbatch ?options script] creates a "sbatch" command that submits the script located in the path [script] with the command line options [?options]. *)
+let sbatch ?(options = []) ?(wrap = false) target =
+  Format.sprintf "%s %s"
+    (Misc.mk_shell_cmd ~options "sbatch")
+    (if wrap then
+      Format.sprintf "--wrap=\"%s\"" target
+    else
+      target)
+
+(** [srun ?options cmd] creates an "srun" command that executes the command [cmd] with the command line options [?options]. *)
+let srun ?(options = []) cmd =
+  Format.sprintf "%s %s" (Misc.mk_shell_cmd ~options "srun") cmd
+
+(** [grep_job_id sbatch_cmd] Given a "sbatch" command, generates a command
+    that extracts from the output of the "sbatch" command the ID of the job
+    that was submitted. *)
+let grep_job_id sbatch_cmd =
+  Format.sprintf "%s | grep -oP \"^Submitted batch job \\K[0-9]+$\"" sbatch_cmd
+
+(** [scancel job_id] creates the command that runs "scancel" on [job_id]. *)
+let scancel job_id = Format.sprintf "scancel %d" job_id
+
+(** [mk_sbatch_cmds limits proof_dir j addr port partition config_file nodes]
+    creates a list of [n] sbatch commands parametrized with the provided
+    options. *)
+let mk_sbatch_cmds limits proof_dir j addr port partition config_file n =
+  let acc_aux opt v cond f acc =
+    if cond v then
+      (opt, f v) :: acc
+    else
+      acc
+  in
+  let aux_acc_limits (limits : Limit.All.t) acc =
+    acc_aux "-t" limits.time Option.is_some
+      (Option.map (fun t -> string_of_int Limit.(Time.as_int Time.Seconds t)))
+    @@ acc_aux "-m" limits.memory Option.is_some
+         (Option.map (fun m ->
+              string_of_int Limit.(Memory.as_int Memory.Megabytes m)))
+         acc
+  in
+  let worker_cmd =
+    let worker_exec =
+      Format.sprintf "%s/benchpress_worker.exe" (Sys.getcwd ())
+    in
+    let worker_cmd_opts =
+      aux_acc_limits limits
+      @@ acc_aux "--proof-dir" proof_dir Option.is_some Fun.id
+      @@ acc_aux "-j" j
+           (function
+             | i when i > 0 -> true
+             | _ -> false)
+           (fun i -> Some (string_of_int i))
+      @@ [
+           "-a", Some (Unix.string_of_inet_addr addr);
+           "-p", Some port;
+           "-c", Some config_file;
+         ]
+    in
+    fun id ->
+      let options = ("--id", Some (string_of_int id)) :: worker_cmd_opts in
+      Misc.mk_shell_cmd ~options worker_exec ^ " >> tmp.txt"
+  in
+  let options =
+    acc_aux "--partition" partition Option.is_some Fun.id
+    @@ [ "--nodes", Some "1"; "--exclusive", None; "--mem", Some "0" ]
+  in
+  let wrap = true in
+  List.init n (fun id ->
+      grep_job_id (sbatch (worker_cmd (id + 1)) ~options ~wrap))

--- a/src/core/Stanza.mli
+++ b/src/core/Stanza.mli
@@ -25,12 +25,28 @@ type git_fetch = GF_fetch | GF_pull
 
 type action =
   | A_run_provers of {
+      j: int option;
       dirs: string list; (* list of directories to examine *)
       pattern: regex option;
       provers: string list;
       timeout: int option;
       memory: int option;
       stack: stack_limit option;
+      loc: Loc.t;
+    }
+  | A_run_provers_slurm of {
+      j: int option;
+      dirs: string list; (* list of directories to examine *)
+      pattern: regex option;
+      provers: string list;
+      timeout: int option;
+      memory: int option;
+      stack: stack_limit option;
+      partition: string option;
+      nodes: int option;
+      addr: Unix.inet_addr option;
+      port: int option;
+      ntasks: int option;
       loc: Loc.t;
     }
   | A_git_checkout of {
@@ -113,3 +129,6 @@ val parse_files : ?reify_errors:bool -> string list -> t list
 val parse_string : ?reify_errors:bool -> filename:string -> string -> t list
 (** Parse a string. See {!parse_files} for the arguments.
     @param filename name used in locations *)
+
+val prover_wl_to_st : Prover.t With_loc.t -> t
+val proof_checker_wl_to_st : Proof_checker.t With_loc.t -> t

--- a/src/worker/Worker.ml
+++ b/src/worker/Worker.ml
@@ -1,0 +1,133 @@
+module Log = (val Logs.src_log (Logs.Src.create "benchpress-worker"))
+
+let spf = Format.sprintf
+
+let copy_problem ~proof_dir ~prover (file : string) : unit =
+  let basename = spf "pb-%s-%s" prover.Prover.name (Filename.basename file) in
+  let new_path = Filename.concat proof_dir basename in
+  Log.debug (fun k -> k "(@[copy-problem@ :from %S@ :to %S@])" file new_path);
+  CCIO.with_out new_path @@ fun oc ->
+  CCIO.with_in file @@ fun ic -> CCIO.copy_into ~bufsize:(64 * 1024) ic oc
+
+let with_proof_file_opt ~proof_file ~keep f =
+  match proof_file with
+  | Some file when not keep ->
+    CCFun.finally ~h:(fun () -> try Sys.remove file with _ -> ()) ~f
+  | _ -> f ()
+
+let run_prover_pb ?proof_dir ~limits ~prover ~pb provers checkers =
+  let prover =
+    try With_loc.view (Misc.Str_map.find prover provers)
+    with Not_found -> Error.failf "cannot find prover '%s'" prover
+  in
+  Error.guard
+    (Error.wrapf "(@[worker: running :prover %a :on %a@])" Prover.pp_name prover
+       Problem.pp pb)
+  @@ fun () ->
+  let proof_file, keep =
+    if prover.Prover.produces_proof then (
+      let pb = pb.Problem.name in
+      let ext = CCOption.get_or ~default:"proof" prover.Prover.proof_ext in
+      let basename =
+        spf "proof-%s-%s.%s" prover.Prover.name (Filename.basename pb) ext
+      in
+      let filename, keep =
+        match proof_dir with
+        | None -> Filename.concat (Filename.dirname pb) basename, false
+        | Some dir ->
+          copy_problem ~proof_dir:dir ~prover pb;
+          Filename.concat dir basename, true
+      in
+      Some filename, keep
+    ) else
+      None, false
+  in
+  with_proof_file_opt ~proof_file ~keep @@ fun () ->
+  let result = Run_prover_problem.run ~limits ~proof_file prover pb in
+  let ev_proof =
+    match result.res, proof_file with
+    | Res.Unsat, Some pfile when prover.Prover.produces_proof ->
+      Log.debug (fun k ->
+          k "proof-file size: %d"
+            (try Unix.((stat pfile).st_size) with _ -> 0));
+      let checker =
+        match prover.Prover.proof_checker with
+        | None -> Error.failf "cannot check proofs for '%s'" prover.name
+        | Some c ->
+          (try With_loc.view (Misc.Str_map.find c checkers)
+           with Not_found -> Error.failf "cannot find proof checker '%s'" c)
+      in
+      let res =
+        let limits = Limit.All.mk ~time:(Limit.Time.mk ~h:1 ()) () in
+        Run_prover_problem.run_proof_check ~limits ~proof_file:pfile prover
+          checker pb
+      in
+      let ev_checker = Run_event.mk_checker res in
+      [ ev_checker ]
+    | _ -> []
+  in
+  Run_event.mk_prover result :: ev_proof
+
+let run_worker ?timeout ?memory (defs : Definitions.t) id socket_addr
+    socket_port j =
+  Log.debug (fun k -> k "(@[run_worker %d: started worker@])" id);
+  let addr = Unix.ADDR_INET (socket_addr, socket_port) in
+  let ic, oc = Unix.open_connection addr in
+  Log.debug (fun k ->
+      k "(@[run_worker %d: connected worker to server %a@])" id
+        Misc.pp_unix_addr addr);
+  let provers =
+    List.fold_left
+      (fun m (With_loc.{ view = Prover.{ name; _ }; _ } as p) ->
+        Misc.Str_map.add name p m)
+      Misc.Str_map.empty
+      (Definitions.all_provers defs)
+  in
+  let checkers =
+    List.fold_left
+      (fun m (With_loc.{ view = Proof_checker.{ name; _ }; _ } as c) ->
+        Misc.Str_map.add name c m)
+      Misc.Str_map.empty
+      (Definitions.all_checkers defs)
+  in
+  let time = Limit.Time.mk ~s:(CCOption.value ~default:0 timeout) () in
+  let memory = Limit.Memory.mk ~m:(CCOption.value ~default:0 memory) () in
+  let limits = Limit.All.mk ~time ~memory () in
+  Log.debug (fun k -> k "(@[run_worker %d: started loop@])" id);
+  try
+    Log.debug (fun k -> k "(@[run_worker %d: sent initial message@])" id);
+    Marshal.to_channel oc (Msg.Worker_response (id, [])) [];
+    flush oc;
+    while true do
+      match Marshal.from_channel ic with
+      | Msg.Worker_task cmds ->
+        Log.debug (fun k ->
+            k "(@[run_worker %d: received %d tasks@])" id (List.length cmds));
+        let reps =
+          List.flatten
+          @@ Misc.Par_map.map_p ~j
+               (fun (prover, pb) ->
+                 run_prover_pb ?proof_dir:None ~limits ~prover ~pb provers
+                   checkers)
+               cmds
+        in
+        Log.debug (fun k ->
+            k "(@[run_worker %d: sent %d responses@])" id (List.length reps));
+        Marshal.to_channel oc (Msg.Worker_response (id, reps)) [];
+        flush oc
+      | Msg.Stop_worker -> raise Exit
+    done
+  with
+  | Exit ->
+    Log.debug (fun k ->
+        k "(@[run_worker %d: received \"Stop\" message from master@])" id);
+    close_out oc
+  | End_of_file ->
+    Log.debug (fun k ->
+        k "(@[run_worker %d: master closed connection \"End_of_file\"@])" id);
+    close_out oc
+  | e ->
+    Log.debug (fun k -> k "(@[run_worker %d: failure! sent exception@])" id);
+    Marshal.to_channel oc (Msg.Worker_failure (id, e)) [];
+    close_out oc;
+    raise e

--- a/src/worker/benchpress_worker.ml
+++ b/src/worker/benchpress_worker.ml
@@ -1,0 +1,57 @@
+let parse_cmdline =
+  let open Cmdliner in
+  let aux defs id socket_addr_opt socket_port j timeout memory =
+    try
+      let socket_addr =
+        match socket_addr_opt with
+        | Some sa -> sa
+        | None ->
+          Error.failf
+            "Provide an IP address for the socket of the master with the \
+             command line argument `-i`."
+      in
+      if id < 0 || socket_port < 0 then
+        Error.failf
+          "The values of the worker id `-i` and the port of the socket of the \
+           master need to be provided and to be strictly positive integers.";
+      Worker.run_worker ?timeout ?memory defs id socket_addr socket_port j;
+      true
+    with Error.E e -> Error.failf "%a@." Error.pp e
+  in
+  let defs = Bin_utils.definitions_term
+  and id =
+    Arg.(
+      value & opt int (-1)
+      & info [ "i"; "id" ] ~doc:"unique stricly positive integer worker ID")
+  and j =
+    Arg.(
+      value
+      & opt int (Misc.guess_cpu_count ())
+      & info [ "j" ] ~doc:"level of parallelism")
+  and socket_addr_opt =
+    Arg.(
+      value
+      & opt (some Misc.ip_addr_conv) None
+      & info [ "a"; "addr" ] ~doc:"IP socket address")
+  and socket_port =
+    Arg.(value & opt int (-1) & info [ "p"; "port" ] ~doc:"IP socket port")
+  and timeout =
+    Arg.(
+      value
+      & opt (some int) None
+      & info [ "t"; "timeout" ] ~doc:"timeout (in seconds)")
+  and memory =
+    Arg.(
+      value & opt (some int) None & info [ "m"; "memory" ] ~doc:"memory (in MB)")
+  in
+  let doc = "" in
+  Cmd.v (Cmd.info ~doc "run")
+    Term.(
+      const aux $ defs $ id $ socket_addr_opt $ socket_port $ j $ timeout
+      $ memory)
+
+let () =
+  match Cmdliner.Cmd.eval_value parse_cmdline with
+  | Error (`Parse | `Term | `Exn) -> exit 2
+  | Ok (`Ok true | `Version | `Help) -> ()
+  | Ok (`Ok false) -> exit 1

--- a/src/worker/dune
+++ b/src/worker/dune
@@ -1,0 +1,20 @@
+(executable
+ (name benchpress_worker)
+ (public_name benchpress-worker)
+ (package benchpress-worker)
+ (modes native)
+ (promote
+  (into ../../)
+  (until-clean))
+ (libraries benchpress containers)
+ (flags :standard -warn-error -a+8 -safe-string -open Benchpress -linkall))
+
+(rule
+ (with-stdout-to
+  benchpress-worker.1
+  (run ./benchpress_worker.exe --help=groff)))
+
+(install
+ (section man)
+ (package benchpress-worker)
+ (files benchpress-worker.1))


### PR DESCRIPTION
Same as `benchpress run` but works with a slurm-managed cluster. It's in the form of a client-server, in which the server runs on the control node of the cluster and its role is to distribute the tasks to the workers and write the results in the db. The workers run on the compute nodes and they run the tasks they receive from the server and send the results back to it.

Although some of the code is duplicated with that of the `run` command, but I though it would be simpler/cleaner to add a separate command for it and it's less likely to break something.

(cc @bobot)