### PR TITLE
Allow naming directories in config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ same repository).
   * custom tags can be used with `(tag foo regex)`: a tag named `foo` will be
     used when `regex` matches the prover's output.
 - `(dir …)` defines a directory:
+  * `(name …)`: unique name used to refer to this directory in the config. You can
+    refer to previously defined directories using `${dir:…}`.
   * `(path …)` defines the path. The rules below apply to any file within this directory.
   * `(pattern ".*.smt2")` means only files matching the (perl) regex will be considered.
   * `(expect …)` defines how to find the expected result of each file (which will

--- a/src/core/Dir.ml
+++ b/src/core/Dir.ml
@@ -12,6 +12,7 @@ type expect =
   | E_try of expect list  (** Try these methods successively *)
 
 type t = {
+  name: string option;
   path: string;
   expect: expect;
   pattern: regex option;  (** Pattern of problems in this directory *)
@@ -24,9 +25,11 @@ let rec pp_expect out = function
   | E_program { prover } -> Fmt.fprintf out "(@[run %a@])" Prover.pp_name prover
   | E_try l -> Fmt.fprintf out "(@[try@ %a@])" (Misc.pp_list pp_expect) l
 
-let pp out { path; expect; pattern; loc = _ } : unit =
+let pp out { name; path; expect; pattern; loc = _ } : unit =
   let open Misc.Pp in
-  Fmt.fprintf out "(@[<v1>dir%a%a%a@])" (pp_f "path" Fmt.string) path
+  Fmt.fprintf out "(@[<v1>dir%a%a%a%a@])"
+    (pp_opt "name" Fmt.string) name
+    (pp_f "path" Fmt.string) path
     (pp_f "expect" pp_expect) expect
     (pp_opt "pattern" pp_regex)
     pattern

--- a/src/core/Stanza.mli
+++ b/src/core/Stanza.mli
@@ -93,6 +93,7 @@ type t =
       invalid: regex;  (** regex for invalid proofs *)
     }
   | St_dir of {
+      name: string option;
       path: string;
       expect: expect option;
       pattern: regex option;  (** Pattern of problems in this directory *)

--- a/tests/conf_prover1.sexp
+++ b/tests/conf_prover1.sexp
@@ -23,6 +23,7 @@
   (inherits fake1))
 
 (dir
+  (name fake)
   (pattern ".*.fake")
   (path $cur_dir/fake_files/))
 
@@ -31,4 +32,4 @@
   (action
     (run_provers
       (provers (fake1 fake2))
-      (dirs ($cur_dir/fake_files/)))))
+      (dirs (${dir:fake})))))


### PR DESCRIPTION
This patch allows naming directories in the config file by setting the (optional) `name` field on a `dir` stanza. Defined directories can be accessed using `${dir:name}` syntax.  See tests/conf_prover1.sexp for an example.

Fixes #32