### PR TITLE
Add ability to compare different provers

### DIFF
--- a/src/bin/Run_main.ml
+++ b/src/bin/Run_main.ml
@@ -36,8 +36,8 @@ let execute_submit_job_action ?pp_results ?j ?timestamp ?dyn ?limits ?proof_dir
     (defs : Definitions.t) (r : Action.run_provers_slurm_submission) :
     _ * Test_compact_result.t =
   Error.guard
-    (Error.wrapf "run provers with slurm action@ `@[%a@]`" Action.pp_run_provers_slurm
-       r)
+    (Error.wrapf "run provers with slurm action@ `@[%a@]`"
+       Action.pp_run_provers_slurm r)
   @@ fun () ->
   let interrupted = CCLock.create false in
   let exp_r =

--- a/src/core/Definitions.ml
+++ b/src/core/Definitions.ml
@@ -17,7 +17,7 @@ type def =
 type t = {
   defs: def Str_map.t;
   dirs: Dir.t list; (* list of directories *)
-  dir_vars : path Str_map.t; (* named directories *)
+  dir_vars: path Str_map.t; (* named directories *)
   errors: Error.t list;
   cur_dir: string; (* for relative paths *)
   config_file: string option;
@@ -56,6 +56,7 @@ let add_dir (d : Dir.t) self : t =
     | None -> self.dir_vars
   in
   { self with dirs = d :: self.dirs; dir_vars }
+
 let errors self = self.errors
 let option_j self = self.option_j
 let option_progress self = self.option_progress

--- a/src/core/Dir.ml
+++ b/src/core/Dir.ml
@@ -27,9 +27,7 @@ let rec pp_expect out = function
 
 let pp out { name; path; expect; pattern; loc = _ } : unit =
   let open Misc.Pp in
-  Fmt.fprintf out "(@[<v1>dir%a%a%a%a@])"
-    (pp_opt "name" Fmt.string) name
-    (pp_f "path" Fmt.string) path
-    (pp_f "expect" pp_expect) expect
+  Fmt.fprintf out "(@[<v1>dir%a%a%a%a@])" (pp_opt "name" Fmt.string) name
+    (pp_f "path" Fmt.string) path (pp_f "expect" pp_expect) expect
     (pp_opt "pattern" pp_regex)
     pattern

--- a/src/core/Stanza.ml
+++ b/src/core/Stanza.ml
@@ -196,8 +196,7 @@ let pp out =
   function
   | St_enter_file f -> Fmt.fprintf out "(@[enter-file@ %a@])" pp_str f
   | St_dir { name; path; expect; pattern; loc = _ } ->
-    Fmt.fprintf out "(@[<v>dir%a%a%a%a@])"
-      (pp_opt "name" Fmt.string) name
+    Fmt.fprintf out "(@[<v>dir%a%a%a%a@])" (pp_opt "name" Fmt.string) name
       (pp_f "path" Fmt.string) path
       (pp_opt "expect" pp_expect)
       expect

--- a/src/core/Test_compare.ml
+++ b/src/core/Test_compare.ml
@@ -27,6 +27,77 @@ module Short = struct
         "regressed", pb_int_color Style.(fg_color Cyan) self.regressed;
       ]
 
+  let make1 db p1 p2 : t =
+    (* Note: first ? is p1, second ? is p2 *)
+    let get_n q =
+      Db.exec db q p1 p2
+        ~ty:Db.Ty.(p2 text text, p1 int, fun x -> x)
+        ~f:(fun c ->
+          match Db.Cursor.next c with
+          | None -> Error.failf "expected result for query\n%s" q
+          | Some x -> x)
+      |> Misc.unwrap_db (fun () -> spf "while running\n%s" q)
+    in
+    let appeared =
+      get_n
+        {| select count(r2.file) from db2.prover_res r2
+                where not exists (select file from db1.prover_res where
+                db1.prover_res.prover= ?
+                and file = r2.file)
+                and r2.prover = ?; |}
+    and disappeared =
+      get_n
+        {| select count(r1.file) from db1.prover_res r1
+                where r1.prover = ?
+                and not exists (select file from db2.prover_res where
+                db2.prover_res.prover=?
+                and file = r1.file); |}
+    and same =
+      get_n
+        {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
+                where
+                  r1.prover = ? and r2.prover = ?
+                  and r1.file = r2.file
+                  and (
+                      (r1.res in ('sat', 'unsat') and r1.res = r2.res)
+                      or
+                      (not (r1.res in ('sat','unsat')) and not (r2.res in ('sat','unsat')))
+                  ) ; |}
+    and mismatch =
+      get_n
+        {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
+                where
+                  (r1.res in ('sat', 'unsat') or r2.res in ('sat', 'unsat'))
+                  and r1.prover = ? and r2.prover = ?
+                  and r1.file = r2.file and r1.res != r2.res; |}
+    and improved =
+      get_n
+        {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
+                where not (r1.res in ('sat', 'unsat'))
+                  and r2.res in ('sat', 'unsat')
+                  and r1.prover = ? and r2.prover = ?
+                  and r1.file = r2.file ; |}
+    and regressed =
+      get_n
+        {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
+                where r1.res in ('sat', 'unsat')
+                  and not (r2.res in ('sat', 'unsat'))
+                  and r1.prover = ? and r2.prover = ?
+                  and r1.file = r2.file ; |}
+    in
+    { appeared; disappeared; same; mismatch; improved; regressed }
+
+  let make_provers (f1, p1) (f2, p2) : t =
+    Error.guard
+      (Error.wrapf "short comparison of '%s/%s' and '%s/%s'" f1 p1 f2 p2)
+    @@ fun () ->
+    let db = Sqlite3.db_open ":memory:" in
+    Db.exec_no_cursor db "attach database ? as db1;" ~ty:Db.Ty.(p1 text) f1
+    |> Misc.unwrap_db (fun () -> spf "attaching DB %S" f1);
+    Db.exec_no_cursor db "attach database ? as db2;" ~ty:Db.Ty.(p1 text) f2
+    |> Misc.unwrap_db (fun () -> spf "attaching DB %S" f2);
+    make1 db p1 p2
+
   let make f1 f2 : (_ * t) list =
     Error.guard (Error.wrapf "short comparison of '%s' and '%s'" f1 f2)
     @@ fun () ->
@@ -44,67 +115,5 @@ module Short = struct
       |> Misc.unwrap_db (fun () -> "listing all provers")
     in
     Logs.debug (fun k -> k "provers: [%s]" (String.concat ";" provers));
-    CCList.map
-      (fun prover ->
-        let get_n q =
-          Db.exec db q prover
-            ~ty:Db.Ty.(p1 text, p1 int, fun x -> x)
-            ~f:(fun c ->
-              match Db.Cursor.next c with
-              | None -> Error.failf "expected result for query\n%s" q
-              | Some x -> x)
-          |> Misc.unwrap_db (fun () -> spf "while running\n%s" q)
-        in
-        let appeared =
-          get_n
-            {| select count(r2.file) from db2.prover_res r2
-                   where r2.prover = ?
-                    and not exists (select file from db1.prover_res where
-                    db1.prover_res.prover=r2.prover
-                    and file = r2.file); |}
-        and disappeared =
-          get_n
-            {| select count(r1.file) from db1.prover_res r1
-                   where r1.prover = ?
-                    and not exists (select file from db2.prover_res where
-                    db2.prover_res.prover=r1.prover
-                    and file = r1.file); |}
-        and same =
-          get_n
-            {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
-                   where
-                      r1.prover = ? and r1.prover = r2.prover
-                      and r1.file = r2.file
-                      and (
-                         (r1.res in ('sat', 'unsat') and r1.res = r2.res)
-                         or
-                         (not (r1.res in ('sat','unsat')) and not (r2.res in ('sat','unsat')))
-                      ) ; |}
-        and mismatch =
-          get_n
-            {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
-                   where
-                      (r1.res in ('sat', 'unsat') or r2.res in ('sat', 'unsat'))
-                      and r1.prover = ? and r1.prover = r2.prover
-                      and r1.file = r2.file and r1.res != r2.res; |}
-        and improved =
-          get_n
-            {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
-                   where not (r1.res in ('sat', 'unsat'))
-                      and r2.res in ('sat', 'unsat')
-                      and r1.prover = ? and r1.prover = r2.prover
-                      and r1.file = r2.file ; |}
-        and regressed =
-          get_n
-            {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
-                   where r1.res in ('sat', 'unsat')
-                      and not (r2.res in ('sat', 'unsat'))
-                      and r1.prover = ? and r1.prover = r2.prover
-                      and r1.file = r2.file ; |}
-        in
-        let c =
-          { appeared; disappeared; same; mismatch; improved; regressed }
-        in
-        prover, c)
-      provers
+    CCList.map (fun prover -> prover, make1 db prover prover) provers
 end

--- a/src/core/Test_compare.mli
+++ b/src/core/Test_compare.mli
@@ -14,6 +14,9 @@ module Short : sig
 
   val to_printbox : t -> PrintBox.t
   val make : filename -> filename -> (Prover.name * t) list
+
+  val make_provers : filename * Prover.name -> filename * Prover.name -> t
+  (** Make a single comparison between two provers in (possibly) different files *)
 end
 
 (* TODO


### PR DESCRIPTION
There is currently a /compare/ endpoint, but sometimes it can be nice/useful to compare two different provers from two different runs.

This PR provides a new endpoint /compare2/ available from the home page that allows to select two arbitrary provers from any two runs and compare them.