### PR TITLE
Add plot and detailed regressions to the prover comparison view

### DIFF
--- a/src/core/Cactus_plot.ml
+++ b/src/core/Cactus_plot.ml
@@ -4,10 +4,14 @@ module Gp = Gnuplot
 
 type t = { lines: (string * Prover.name * float list) list }
 
-let of_db db =
+let of_db ?provers db =
   Error.guard (Error.wrap "producting cactus plot") @@ fun () ->
   Profile.with_ "plot.of-db" @@ fun () ->
-  let provers = list_provers db in
+  let provers =
+    match provers with
+    | Some provers -> provers
+    | None -> list_provers db
+  in
   Logs.debug (fun k -> k "provers: [%s]" (String.concat ";" provers));
   let has_custom_tags =
     try
@@ -47,8 +51,8 @@ let combine (l : (_ * t) list) : t =
         l;
   }
 
-let of_file file : t =
-  try Db.with_db ~timeout:500 ~mode:`READONLY file of_db
+let of_file ?provers file : t =
+  try Db.with_db ~timeout:500 ~mode:`READONLY file (of_db ?provers)
   with e -> Error.(raise @@ of_exn e)
 
 let to_gp ~output self =

--- a/src/core/Cactus_plot.mli
+++ b/src/core/Cactus_plot.mli
@@ -6,8 +6,8 @@ open Misc
 
 type t
 
-val of_db : Db.t -> t
-val of_file : string -> t
+val of_db : ?provers:Prover.name list -> Db.t -> t
+val of_file : ?provers:Prover.name list -> string -> t
 val combine : (string * t) list -> t
 val show : t -> unit
 val save_to_file : t -> string -> unit

--- a/src/core/Res.ml
+++ b/src/core/Res.ml
@@ -23,6 +23,15 @@ let of_string ~tags = function
 
 let pp out s = Fmt.string out (to_string s)
 
+let to_printbox =
+  let open PrintBox in
+  function
+  | (Sat | Unsat) as r ->
+    text_with_style Style.(set_fg_color Green @@ bold) @@ to_string r
+  | Error as r ->
+    text_with_style Style.(set_fg_color Red @@ bold) @@ to_string r
+  | r -> text @@ to_string r
+
 let compare a b =
   match a, b with
   | Unsat, Unsat

--- a/src/core/Res.mli
+++ b/src/core/Res.mli
@@ -19,3 +19,4 @@ val compare : t -> t -> [ `Same | `LeftBetter | `RightBetter | `Mismatch ]
 val pp : t CCFormat.printer
 val to_string : t -> string
 val of_string : tags:string list -> string -> t
+val to_printbox : t -> PrintBox.t

--- a/src/core/Test_compare.ml
+++ b/src/core/Test_compare.ml
@@ -1,9 +1,72 @@
 open Common
 
 type filename = string
+type prover = filename * Prover.name
 
 let pb_v_record = Test.pb_v_record
 let pb_int_color = Test.pb_int_color
+
+(* Common helpers *)
+let make_db f1 f2 =
+  let db = Sqlite3.db_open ":memory:" in
+  Db.exec_no_cursor db "attach database ? as db1;" ~ty:Db.Ty.(p1 text) f1
+  |> Misc.unwrap_db (fun () -> spf "attaching DB %S" f1);
+  Db.exec_no_cursor db "attach database ? as db2;" ~ty:Db.Ty.(p1 text) f2
+  |> Misc.unwrap_db (fun () -> spf "attaching DB %S" f2);
+  db
+
+let cmp2sql = function
+  | `Same ->
+    {|
+      (r1.res in ('sat', 'unsat') and r1.res = r2.res)
+      or
+      (r1.res not in ('sat', 'unsat') and r2.res not in ('sat', 'unsat'))
+    |}
+  | `Mismatch ->
+    {|
+      r1.res in ('sat', 'unsat') and
+      r2.res in ('sat', 'unsat') and
+      r1.res != r2.res
+    |}
+  | `Improved ->
+    {| r1.res not in ('sat', 'unsat') and r2.res in ('sat', 'unsat') |}
+  | `Regressed ->
+    {| r1.res in ('sat', 'unsat') and r2.res not in ('sat', 'unsat') |}
+
+let pp_cmp = Fmt.of_to_string cmp2sql
+
+let pp_opt ?(none = Fmt.const_string "") pp ppf = function
+  | None -> none ppf ()
+  | Some v -> pp ppf v
+
+let pp_prefix prefix pp ppf v =
+  Fmt.fprintf ppf "%s" prefix;
+  pp ppf v
+
+let unsafe_sql ?order ?limit ?offset ?filter select =
+  let pp_filter ppf filter =
+    match filter with
+    | None -> ()
+    | Some filter -> Format.fprintf ppf "and (%a)" pp_cmp filter
+  in
+  let pp_select =
+    Fmt.list
+      ~sep:(fun ppf () -> Fmt.fprintf ppf ",@,")
+      (fun ppf s -> Fmt.fprintf ppf "(%s)" s)
+  in
+  Fmt.asprintf
+    {| select %a
+        from db1.prover_res r1
+        inner join db2.prover_res r2 on r2.file = r1.file
+        where r1.prover = ? and r2.prover = ? %a %a %a %a
+      |}
+    pp_select select pp_filter filter
+    (pp_opt (pp_prefix " order by " Fmt.string))
+    order
+    (pp_opt (pp_prefix " limit " Fmt.int))
+    limit
+    (pp_opt (pp_prefix " offset " Fmt.int))
+    offset
 
 module Short = struct
   type t = {
@@ -52,51 +115,18 @@ module Short = struct
                 and not exists (select file from db2.prover_res where
                 db2.prover_res.prover=?
                 and file = r1.file); |}
-    and same =
-      get_n
-        {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
-                where
-                  r1.prover = ? and r2.prover = ?
-                  and r1.file = r2.file
-                  and (
-                      (r1.res in ('sat', 'unsat') and r1.res = r2.res)
-                      or
-                      (not (r1.res in ('sat','unsat')) and not (r2.res in ('sat','unsat')))
-                  ) ; |}
-    and mismatch =
-      get_n
-        {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
-                where
-                  (r1.res in ('sat', 'unsat') or r2.res in ('sat', 'unsat'))
-                  and r1.prover = ? and r2.prover = ?
-                  and r1.file = r2.file and r1.res != r2.res; |}
-    and improved =
-      get_n
-        {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
-                where not (r1.res in ('sat', 'unsat'))
-                  and r2.res in ('sat', 'unsat')
-                  and r1.prover = ? and r2.prover = ?
-                  and r1.file = r2.file ; |}
+    and same = get_n (unsafe_sql ~filter:`Same [ "count(r1.file)" ])
+    and mismatch = get_n (unsafe_sql ~filter:`Mismatch [ "count(r1.file)" ])
+    and improved = get_n (unsafe_sql ~filter:`Improved [ "count(r1.file)" ])
     and regressed =
-      get_n
-        {| select count(r1.file) from db1.prover_res r1, db2.prover_res r2
-                where r1.res in ('sat', 'unsat')
-                  and not (r2.res in ('sat', 'unsat'))
-                  and r1.prover = ? and r2.prover = ?
-                  and r1.file = r2.file ; |}
+      get_n (unsafe_sql ~filter:`Regressed [ "count(r1.file)" ])
     in
     { appeared; disappeared; same; mismatch; improved; regressed }
 
   let make_provers (f1, p1) (f2, p2) : t =
     Error.guard
       (Error.wrapf "short comparison of '%s/%s' and '%s/%s'" f1 p1 f2 p2)
-    @@ fun () ->
-    let db = Sqlite3.db_open ":memory:" in
-    Db.exec_no_cursor db "attach database ? as db1;" ~ty:Db.Ty.(p1 text) f1
-    |> Misc.unwrap_db (fun () -> spf "attaching DB %S" f1);
-    Db.exec_no_cursor db "attach database ? as db2;" ~ty:Db.Ty.(p1 text) f2
-    |> Misc.unwrap_db (fun () -> spf "attaching DB %S" f2);
-    make1 db p1 p2
+    @@ fun () -> make1 (make_db f1 f2) p1 p2
 
   let make f1 f2 : (_ * t) list =
     Error.guard (Error.wrapf "short comparison of '%s' and '%s'" f1 f2)
@@ -116,4 +146,50 @@ module Short = struct
     in
     Logs.debug (fun k -> k "provers: [%s]" (String.concat ";" provers));
     CCList.map (fun prover -> prover, make1 db prover prover) provers
+end
+
+module Full = struct
+  type filter = [ `Improved | `Regressed | `Mismatch | `Same ]
+  type entry = string * Res.t * float * Res.t * float
+
+  let make_filtered ?(page = 0) ?(page_size = 500) ?filter (f1, p1) (f2, p2) =
+    let tags = [] (* TODO? *) in
+    let offset = page * page_size in
+    let limit = page_size + 1 in
+    Db.exec (make_db f1 f2)
+      (unsafe_sql ~order:"r1.file desc" ~limit ~offset ?filter
+         [ "r1.file"; "r1.res"; "r2.res"; "r1.rtime"; "r2.rtime" ])
+      p1 p2
+      ~ty:
+        Db.Ty.(
+          ( p2 text text,
+            [ any_str; text; text; float; float ],
+            fun file res1 res2 time1 time2 ->
+              let res1 = Res.of_string ~tags res1 in
+              let res2 = Res.of_string ~tags res2 in
+              file, res1, time1, res2, time2 ))
+      ~f:Db.Cursor.to_list_rev
+    |> Misc.unwrap_db (fun () -> spf "listing comparison results")
+
+  let to_printbox ?(file_link = Test.default_pp_linker) vals =
+    let open PrintBox in
+    let hdr = text_with_style Style.bold in
+    grid_l ~bars:true
+      ([
+         hdr "file";
+         hdr "old res";
+         hdr "old time";
+         hdr "new res";
+         hdr "new time";
+       ]
+      :: List.map
+           (fun (fname, res1, time1, res2, time2) ->
+             [
+               file_link fname fname;
+               Res.to_printbox res1;
+               float time1;
+               Res.to_printbox res2;
+               float time2;
+             ])
+           vals)
 end

--- a/src/core/Test_compare.mli
+++ b/src/core/Test_compare.mli
@@ -1,6 +1,7 @@
 (** Compare two result files *)
 
 type filename = string
+type prover = filename * Prover.name
 
 module Short : sig
   type t = {
@@ -15,8 +16,24 @@ module Short : sig
   val to_printbox : t -> PrintBox.t
   val make : filename -> filename -> (Prover.name * t) list
 
-  val make_provers : filename * Prover.name -> filename * Prover.name -> t
+  val make_provers : prover -> prover -> t
   (** Make a single comparison between two provers in (possibly) different files *)
+end
+
+module Full : sig
+  type filter = [ `Improved | `Regressed | `Mismatch | `Same ]
+  type entry = string * Res.t * float * Res.t * float
+
+  val make_filtered :
+    ?page:int ->
+    ?page_size:int ->
+    ?filter:filter ->
+    prover ->
+    prover ->
+    entry list
+
+  val to_printbox :
+    ?file_link:(string -> string -> PrintBox.t) -> entry list -> PrintBox.t
 end
 
 (* TODO

--- a/src/core/Test_detailed_res.ml
+++ b/src/core/Test_detailed_res.ml
@@ -183,14 +183,7 @@ let to_printbox ?link:(mk_link = default_pp_linker) (self : t)
     PB.t * PB.t * string * string * string option =
   let open PB in
   Logs.debug (fun k -> k "coucou");
-  let pp_res r =
-    match r with
-    | Res.Sat | Res.Unsat ->
-      text_with_style Style.(set_fg_color Green @@ bold) @@ Res.to_string r
-    | Res.Error ->
-      text_with_style Style.(set_fg_color Red @@ bold) @@ Res.to_string r
-    | _ -> text @@ Res.to_string r
-  and pp_proof_res = function
+  let pp_proof_res = function
     | Proof_check_res.Valid ->
       text_with_style Style.(set_fg_color Green @@ bold) "valid"
     | Proof_check_res.Invalid ->
@@ -208,8 +201,8 @@ let to_printbox ?link:(mk_link = default_pp_linker) (self : t)
          [
            ( "problem.path",
              mk_link self.program.Prover.name self.problem.Problem.name );
-           "problem.expected_res", pp_res self.problem.Problem.expected;
-           "res", pp_res self.res;
+           "problem.expected_res", Res.to_printbox self.problem.Problem.expected;
+           "res", Res.to_printbox self.res;
          ];
          [
            "rtime", text (Misc.human_duration self.raw.rtime);


### PR DESCRIPTION
This PR is a follow-up to #63.

It adds the comparison plot to the prover comparison view, as well as the list of regressed and improved files inline. The lists are hidden by default using HTML5 summary/details.
This is similar to what is done for errors in the main file view.

The regression/improvement listing is implemented using a new Test_compare.Full module that returns a
list of detailed information for each file.

Only up to 500 regressed and improved files are displayed, to avoid
overloading the page with information.  To view the rest of the
improvements/regressions, if there is more than 500, a separate
paginated view should be created, but this is left for future work.

Plot view: 
![image](https://user-images.githubusercontent.com/129742207/235129270-9d5b0147-6fb4-4d94-9949-a86579921d80.png)

Regression view (improvements is similar; file names redacted for legal reasons):
![image](https://user-images.githubusercontent.com/129742207/235130060-26410d62-0e9c-4d97-b976-08272aded920.png)
