### PR TITLE
Add support for dir_files (like -F) in run stanzas

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ same repository).
   * `(provers (p1 … pn))` list of (names of) provers defined in other stanzas
   * `(dirs (p1 … pn))` paths containing benchmarks. The paths must be subdirectories
     of already defined directories (see the `dir` stanza above)
+  * `(dir_files (p1 … pn))` paths to files containing problem paths, one
+    problem path per line.  Each line can also be a directory, in which case
+    all the problems in the directory will be added. The same restrictions as
+    for `dirs` apply. This has the same behavior as option `-F`.
   * `(timeout n)` (optional) defines a timeout in seconds
   * `(memory n)` (optional) defines a memory limit in MB
   * `(pattern regex)` (optional) an additional regex for files to consider in `dirs`

--- a/src/bin/Run_main.ml
+++ b/src/bin/Run_main.ml
@@ -69,7 +69,7 @@ type top_task =
       Action.run_provers_slurm_submission * Definitions.t
 
 let main ?j ?pp_results ?dyn ?timeout ?memory ?csv ?(provers = []) ?meta:_
-    ?summary ?task ?dir_file ?proof_dir ?output ?(save = true)
+    ?summary ?task ?(dir_files = []) ?proof_dir ?output ?(save = true)
     ?(wal_mode = false) ~desktop_notification ~no_failure ~update
     ?(sbatch = false) ?partition ?nodes ?addr ?port ?ntasks
     (defs : Definitions.t) paths () : unit =
@@ -78,13 +78,7 @@ let main ?j ?pp_results ?dyn ?timeout ?memory ?csv ?(provers = []) ?meta:_
   let timestamp = Unix.gettimeofday () in
   let notify = Notify.make defs in
   (* parse list of files, if need be *)
-  let paths =
-    match dir_file with
-    | None -> paths
-    | Some f ->
-      let f_lines = CCIO.with_in f CCIO.read_lines_l in
-      List.rev_append f_lines paths
-  in
+  let paths = Definitions.mk_paths ~dir_files paths in
   (* parse config *)
   let tt_task =
     match task with

--- a/src/bin/benchpress_bin.ml
+++ b/src/bin/benchpress_bin.ml
@@ -19,7 +19,7 @@ module Run = struct
   (* sub-command for running tests *)
   let cmd =
     let open Cmdliner in
-    let aux j pp_results dyn paths dir_file proof_dir defs task timeout memory
+    let aux j pp_results dyn paths dir_files proof_dir defs task timeout memory
         meta provers csv summary no_color output save wal_mode
         desktop_notification no_failure update =
       catch_err @@ fun () ->
@@ -31,7 +31,7 @@ module Run = struct
           None
       in
       Run_main.main ~pp_results ?dyn ~j ?timeout ?memory ?csv ~provers ~meta
-        ?task ?summary ?dir_file ?proof_dir ?output ~save ~wal_mode
+        ?task ?summary ~dir_files ?proof_dir ?output ~save ~wal_mode
         ~desktop_notification ~no_failure ~update defs paths ()
     in
     let defs = Bin_utils.definitions_term
@@ -49,10 +49,10 @@ module Run = struct
       Arg.(value & opt bool true & info [ "save" ] ~doc:"save results on disk")
     and wal_mode =
       Arg.(value & flag & info [ "wal" ] ~doc:"turn on the journal WAL mode")
-    and dir_file =
+    and dir_files =
       Arg.(
         value
-        & opt (some string) None
+        & opt_all file []
         & info [ "F" ] ~doc:"file containing a list of files")
     and proof_dir =
       Arg.(
@@ -123,7 +123,7 @@ module Run = struct
     in
     Cmd.v (Cmd.info ~doc "run")
       Term.(
-        const aux $ j $ pp_results $ dyn $ paths $ dir_file $ proof_dir $ defs
+        const aux $ j $ pp_results $ dyn $ paths $ dir_files $ proof_dir $ defs
         $ task $ timeout $ memory $ meta $ provers $ csv $ summary $ no_color
         $ output $ save $ wal_mode $ desktop_notification $ no_failure $ update)
 end
@@ -132,7 +132,7 @@ module Slurm = struct
   (* sub-command for running tests with slurm *)
   let cmd =
     let open Cmdliner in
-    let aux j pp_results dyn paths dir_file proof_dir defs task timeout memory
+    let aux j pp_results dyn paths dir_files proof_dir defs task timeout memory
         meta provers csv summary no_color output save wal_mode
         desktop_notification no_failure update partition nodes addr port ntasks
         =
@@ -145,7 +145,7 @@ module Slurm = struct
           None
       in
       Run_main.main ~sbatch:true ~pp_results ?dyn ~j ?timeout ?memory ?csv
-        ~provers ~meta ?task ?summary ?dir_file ?proof_dir ?output ~wal_mode
+        ~provers ~meta ?task ?summary ~dir_files ?proof_dir ?output ~wal_mode
         ~desktop_notification ~no_failure ~update ~save ?partition ?nodes ?addr
         ?port ?ntasks defs paths ()
     in
@@ -167,10 +167,10 @@ module Slurm = struct
       Arg.(value & opt bool true & info [ "save" ] ~doc:"save results on disk")
     and wal_mode =
       Arg.(value & flag & info [ "wal" ] ~doc:"turn on the journal WAL mode")
-    and dir_file =
+    and dir_files =
       Arg.(
         value
-        & opt (some string) None
+        & opt_all file []
         & info [ "F" ] ~doc:"file containing a list of files")
     and proof_dir =
       Arg.(
@@ -279,7 +279,7 @@ module Slurm = struct
     in
     Cmd.v (Cmd.info ~doc "slurm")
       Term.(
-        const aux $ j $ pp_results $ dyn $ paths $ dir_file $ proof_dir $ defs
+        const aux $ j $ pp_results $ dyn $ paths $ dir_files $ proof_dir $ defs
         $ task $ timeout $ memory $ meta $ provers $ csv $ summary $ no_color
         $ output $ save $ wal_mode $ desktop_notification $ no_failure $ update
         $ partition $ nodes $ addr $ port $ ntasks)

--- a/src/core/Definitions.mli
+++ b/src/core/Definitions.mli
@@ -41,6 +41,7 @@ val add_stanza : ?reify_errors:bool -> Stanza.t -> t -> t
 val add_stanza_l : ?reify_errors:bool -> Stanza.t list -> t -> t
 val of_stanza_l : ?reify_errors:bool -> Stanza.t list -> t
 val mk_subdir : t -> string -> Subdir.t
+val mk_paths : ?dir_files:string list -> string list -> string list
 
 val mk_run_provers :
   ?j:int ->

--- a/src/core/Misc.ml
+++ b/src/core/Misc.ml
@@ -107,6 +107,10 @@ module Pp = struct
     | None -> ()
     | Some x -> Fmt.fprintf out "@ (@[%s@ %a@])" what f x
 
+  let pp_fl1 what f out = function
+    | [] -> ()
+    | l -> pp_f what (pp_l f) out l
+
   let pp_l1 f out l =
     if l = [] then
       ()

--- a/src/core/Stanza.mli
+++ b/src/core/Stanza.mli
@@ -27,6 +27,7 @@ type action =
   | A_run_provers of {
       j: int option;
       dirs: string list; (* list of directories to examine *)
+      dir_files: string list; (* list of files containing directories, as in option -F *)
       pattern: regex option;
       provers: string list;
       timeout: int option;
@@ -37,6 +38,7 @@ type action =
   | A_run_provers_slurm of {
       j: int option;
       dirs: string list; (* list of directories to examine *)
+      dir_files: string list; (* list of files containing directories, as in option -F *)
       pattern: regex option;
       provers: string list;
       timeout: int option;


### PR DESCRIPTION
This PR adds support for a dir_files field in run stanzas. The dir_files field behaves like the -F option on the command line: it takes path(s) to a file (or files) that themselves contain paths to benchmarks (one per line).