### PR TITLE
Add (binary) field to (prover) stanzas

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ same repository).
   * `name`: unique name, used to refer to this prover in results, on the command line, etc
   * `cmd`: how to run the prover. Variables `$timeout`, `$file`, `$memory` are
     available and will refer to parameters used to run the prover on a file.
+    Variable `$binary` refers to the `binary` field if set, see below.
+  * `binary`: path to the prover binary. If not provided, will be inferred as
+    the first argument of the `cmd`.
   * `sat`, `unsat`, `unknown`, `timeout`, `memory` are (perl) regex used to recognize
     the result (or reason for failure by timeout or memory exhaustion) of the prover.
   * custom tags can be used with `(tag foo regex)`: a tag named `foo` will be

--- a/src/core/Stanza.ml
+++ b/src/core/Stanza.ml
@@ -72,6 +72,7 @@ type t =
       name: string;
       loc: Loc.t;
       version: version_field option;
+      binary: string option;
       cmd: string option;
       produces_proof: bool option;
       proof_ext: string option;
@@ -212,6 +213,7 @@ let pp out =
   | St_prover
       {
         name;
+        binary;
         cmd;
         version;
         unsat;
@@ -230,8 +232,10 @@ let pp out =
     let pp_custom out (x, y) =
       Fmt.fprintf out "(@[tag %a@ %a@])" pp_str x pp_regex y
     in
-    Fmt.fprintf out "(@[<v>prover%a%a%a%a%a%a%a%a%a%a%a%a%a%a@])"
-      (pp_f "name" pp_str) name (pp_opt "cmd" pp_str) cmd
+    Fmt.fprintf out "(@[<v>prover%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a@])"
+      (pp_f "name" pp_str) name
+      (pp_opt "binary" pp_str) binary
+      (pp_opt "cmd" pp_str) cmd
       (pp_opt "version" pp_version_field)
       version
       (pp_opt "ulimits" Ulimit.pp)
@@ -481,6 +485,7 @@ let dec (st : state) : t list SD.t =
           CCOpt.get_or ~default:[] l
         in
         let* name = Fields.field m "name" string in
+        let* binary = Fields.field_opt m "binary" string in
         let* cmd = Fields.field_opt m "cmd" string in
         let* version = Fields.field_opt m "version" dec_version in
         let* sat = Fields.field_opt m "sat" dec_regex in
@@ -505,6 +510,7 @@ let dec (st : state) : t list SD.t =
           St_prover
             {
               name;
+              binary;
               cmd;
               version;
               sat;
@@ -637,6 +643,7 @@ let prover_wl_to_st
           Prover.
             {
               name;
+              binary;
               cmd;
               sat;
               unsat;
@@ -657,6 +664,7 @@ let prover_wl_to_st
   St_prover
     {
       name;
+      binary = Some binary;
       cmd = Some cmd;
       sat;
       unsat;

--- a/src/core/Stanza.mli
+++ b/src/core/Stanza.mli
@@ -67,6 +67,8 @@ type t =
       name: string;
       loc: Loc.t;
       version: version_field option;
+      binary: string option;
+          (** Path to the binary to use.  Useful in combination with [inherits] *)
       cmd: string option;
           (** the command line to run.
           possibly contains $binary, $file, $memory and $timeout,

--- a/tests/conf_prover1.sexp
+++ b/tests/conf_prover1.sexp
@@ -2,11 +2,11 @@
 (import-prelude false)
 
 (prover
-  (cmd "$cur_dir/fake_prover.sh $file") ; yep, pretty fake
+  (name templ1)
+  (cmd "$binary $file")
   (sat "^SAT")
   (unsat "^UNSAT")
-  (unknown "^UNKNOWN")
-  (name fake1))
+  (unknown "^UNKNOWN"))
 
 (proof_checker
   (name gadget)
@@ -15,12 +15,22 @@
   (invalid "^INVALID"))
 
 (prover
-  (name fake2)
-  (cmd "$cur_dir/fake_prover.sh $file $proof_file")
+  (name templ2)
+  (cmd "$binary $file $proof_file")
   (proof_ext "notreallyaproof")
   (produces_proof true)
   (proof_checker gadget)
-  (inherits fake1))
+  (inherits templ1))
+
+(prover
+  (name fake1)
+  (binary "$cur_dir/fake_prover.sh") ; yep, pretty fake
+  (inherits templ1))
+
+(prover
+  (name fake2)
+  (binary "$cur_dir/fake_prover.sh")
+  (inherits templ2))
 
 (dir
   (name fake)


### PR DESCRIPTION
This mostly exposes the existing `binary` field from the `Prover.t` through the stanzas. If not provided, the `binary` field will be inferred from the `cmd` as before.

This is useful to define "template" provers that define a shared set of options in the `cmd` field and can be reused with `inherits` to target different versions of the same prover with these options.