### PR TITLE
Use single-argument ulimit calls

### DIFF
--- a/src/core/Proof_checker.ml
+++ b/src/core/Proof_checker.ml
@@ -43,12 +43,12 @@ let make_cmd ?env ~problem ~proof_file (self : t) : string =
 let run ?(limits = Limit.All.default) ~problem ~proof_file (self : t) =
   let cmd = make_cmd ~problem ~proof_file self in
   let ulimit = Ulimit.mk ~time:true ~memory:true ~stack:true in
-  let prefix =
-    Ulimit.cmd ~conf:ulimit
+  let cmd =
+    Ulimit.prefix_cmd ~conf:ulimit
       ~limits:
         (Limit.All.update_time (CCOpt.map Limit.Time.(add (mk ~s:1 ()))) limits)
+      ~cmd
   in
-  let cmd = Ulimit.prefix_cmd ?prefix ~cmd () in
   Run_proc.run cmd
 
 let analyze_res (self : t) (res : Run_proc_result.t) : Res.t option =

--- a/src/core/Prover.ml
+++ b/src/core/Prover.ml
@@ -202,12 +202,12 @@ let run ?env ?proof_file ~limits ~file (self : t) : Run_proc_result.t =
   let cmd = make_command ?env ?proof_file ~limits self ~file in
   (* Give one more second to the ulimit timeout to account for the startup
      time and the time elasped between starting ulimit and starting the prover *)
-  let prefix =
-    Ulimit.cmd ~conf:self.ulimits
+  let cmd =
+    Ulimit.prefix_cmd ~conf:self.ulimits
       ~limits:
         (Limit.All.update_time (CCOpt.map Limit.Time.(add (mk ~s:1 ()))) limits)
+      ~cmd
   in
-  let cmd = Ulimit.prefix_cmd ?prefix ~cmd () in
   Run_proc.run cmd
 
 let analyze_p_opt (self : t) (r : Run_proc_result.t) : Res.t option =

--- a/src/core/Ulimit.mli
+++ b/src/core/Ulimit.mli
@@ -16,9 +16,6 @@ val pp : conf CCFormat.printer
 val mk : time:bool -> memory:bool -> stack:bool -> conf
 (** Create a ulimit conf. *)
 
-val cmd : conf:conf -> limits:Limit.All.t -> string option
-(** Given a ulimit conf, and a set of limits, return an adequate command
-    (if any is necessary) to enforce the limits using ulimit. *)
-
-val prefix_cmd : ?prefix:string -> cmd:string -> unit -> string
-(** Adequately prefix the given command with the optional given prefix command. *)
+val prefix_cmd : conf:conf -> limits:Limit.All.t -> cmd:string -> string
+(** Given a ulimit configuration and a set of limits, prefix the given command
+    with the adequate `ulimit` calls, if necessary, to enforce the limits. *)


### PR DESCRIPTION
Some ulimit implementations (at least the one in dash, which is the /bin/sh implementation used by Debian derivatives) only accept setting one limit at a time.

```shell
$ dash
$ ulimit -t 20 -m 20
dash: 1: ulimit: too many arguments
```

This causes the limits set by benchpress to be ignored on these implementations when there are multiple (e.g. time and memory) limits. This patch changes the behavior to build a sequence of unrelated calls to `ulimit` (so `ulimit -t 20 ; ulimit -m 20 ; my_prover` instead of `ulimit -t 20 -m 20 ; my_prover`) for compatibility with these implementations.

(I had seen the `ulimit: too many arguments` error messages many times in prover outputs without paying too much attention to it as it seemed to still work, but yesterday we had runaway prover instances that did not stop after 18+ hours which was definite proof it *didn't* work (: )