### PR TITLE
Add support for comparing results with a specific status

### DIFF
--- a/src/core/Test_compare.ml
+++ b/src/core/Test_compare.ml
@@ -36,15 +36,11 @@ let cmp2sql = function
 
 let pp_cmp = Fmt.of_to_string cmp2sql
 
-let status_to_string = function
-  | `Sat -> {|
-      (r1.res = 'sat' or r2.res = 'sat')
-    |}
-  | `Unsat -> {|
-      (r1.res = 'unsat' or r2.res = 'unsat')
-    |}
+let status_to_sql = function
+  | `Sat -> {| (r1.res = 'sat' or r2.res = 'sat') |}
+  | `Unsat -> {| (r1.res = 'unsat' or r2.res = 'unsat') |}
 
-let pp_status = Fmt.of_to_string status_to_string
+let pp_status_sql = Fmt.of_to_string status_to_sql
 
 let pp_opt ?(none = Fmt.const_string "") pp ppf = function
   | None -> none ppf ()
@@ -60,7 +56,7 @@ let unsafe_sql ?order ?limit ?offset ?filter ?status select =
     | None -> ()
     | Some filter -> Format.fprintf ppf "and (%a)" pp_cmp filter
   in
-  let pp_status = pp_opt (pp_prefix " and " pp_status) in
+  let pp_status = pp_opt (pp_prefix " and " pp_status_sql) in
   let pp_select =
     Fmt.list
       ~sep:(fun ppf () -> Fmt.fprintf ppf ",@,")

--- a/src/core/Test_compare.mli
+++ b/src/core/Test_compare.mli
@@ -2,6 +2,7 @@
 
 type filename = string
 type prover = filename * Prover.name
+type status = [ `Sat | `Unsat ]
 
 module Short : sig
   type t = {
@@ -14,9 +15,9 @@ module Short : sig
   }
 
   val to_printbox : t -> PrintBox.t
-  val make : filename -> filename -> (Prover.name * t) list
+  val make : ?status:status -> filename -> filename -> (Prover.name * t) list
 
-  val make_provers : prover -> prover -> t
+  val make_provers : ?status:status -> prover -> prover -> t
   (** Make a single comparison between two provers in (possibly) different files *)
 end
 
@@ -28,6 +29,7 @@ module Full : sig
     ?page:int ->
     ?page_size:int ->
     ?filter:filter ->
+    ?status:status ->
     prover ->
     prover ->
     entry list


### PR DESCRIPTION
This patch gives the option to compare only sat/unsat results in the compare2 view (the one that allows to select provers from different runs).