### PR TITLE
[compare2] Add total time for problems solved by both provers

### DIFF
--- a/src/core/Test_compare.mli
+++ b/src/core/Test_compare.mli
@@ -12,6 +12,9 @@ module Short : sig
     regressed: int;
     mismatch: int;
     same: int; (* same result *)
+    solved: int; (* same solved result *)
+    old_time: float; (* same solved result *)
+    new_time: float; (* same solved result *)
   }
 
   val to_printbox : t -> PrintBox.t
@@ -22,7 +25,7 @@ module Short : sig
 end
 
 module Full : sig
-  type filter = [ `Improved | `Regressed | `Mismatch | `Same ]
+  type filter = [ `Improved | `Regressed | `Mismatch | `Same | `Solved ]
   type entry = string * Res.t * float * Res.t * float
 
   val make_filtered :

--- a/src/server/benchpress_server.ml
+++ b/src/server/benchpress_server.ml
@@ -1228,12 +1228,14 @@ let handle_compare2 self : unit =
         | `Regressed -> short.regressed
         | `Mismatch -> short.mismatch
         | `Same -> short.same
+        | `Solved -> short.solved
       in
       let filter_to_string = function
         | `Improved -> "Improved"
         | `Regressed -> "Regressed"
         | `Mismatch -> "Mismatch"
         | `Same -> "Same"
+        | `Solved -> "Solved"
       in
       let short = Test_compare.Short.make_provers ?status (ff1, p1) (ff2, p2) in
       let make filter =


### PR DESCRIPTION
This patch adds the number of problems that are solved by both provers (with identical results, barring soundness issues) in the `compare2` view, as well as the time each prover took to solve only those shared problems.  This provides a more meaningful way of comparing different provers' runtime.