### PR TITLE
Remove missing license warning when pinning with opam

### DIFF
--- a/benchpress-lsp.opam
+++ b/benchpress-lsp.opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 version: "0.1"
+license: "BSD-2-Clause"
 authors: ["Simon Cruanes" "Guillaume Bury"]
 synopsis: "LSP server for benchpress' config files"
 maintainer: "simon.cruanes.2007@m4x.org"

--- a/benchpress-server.opam
+++ b/benchpress-server.opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 version: "0.1"
+license: "BSD-2-Clause"
 authors: ["Simon Cruanes" "Guillaume Bury"]
 synopsis: "Server and web UI for benchpress"
 maintainer: "simon.cruanes.2007@m4x.org"

--- a/benchpress-server.opam
+++ b/benchpress-server.opam
@@ -21,7 +21,7 @@ depends: [
   "gnuplot" { >= "0.6" & < "0.8" }
   "sqlite3"
   "sqlite3_utils" { >= "0.4" & < "0.5" }
-  "tiny_httpd" { >= "0.16" & < "1.0" }
+  "tiny_httpd" { >= "0.17" & < "1.0" }
   "printbox" { >= "0.6" }
   "printbox-text" { >= "0.6" }
   "ocaml" {>= "4.12" }

--- a/benchpress-worker.opam
+++ b/benchpress-worker.opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 version: "0.1"
+license: "BSD-2-Clause"
 authors: ["Simon Cruanes" "Guillaume Bury" "Hichem Rami Ait El Hara"]
 synopsis: "A benchpress helper worker"
 maintainer: "simon.cruanes.2007@m4x.org"

--- a/benchpress.opam
+++ b/benchpress.opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 version: "0.1"
+license: "BSD-2-Clause"
 authors: ["Simon Cruanes" "Guillaume Bury"]
 synopsis: "Tool to run one or more logic programs, on a set of files, and collect the results"
 maintainer: "simon.cruanes.2007@m4x.org"

--- a/src/server/benchpress_server.ml
+++ b/src/server/benchpress_server.ml
@@ -2,7 +2,7 @@
 open Common
 module T = Test
 module H = Tiny_httpd
-module U = Tiny_httpd_util
+module U = Tiny_httpd.Util
 module PB = PrintBox
 module Log = (val Logs.src_log (Logs.Src.create "benchpress-serve"))
 
@@ -1746,9 +1746,9 @@ let handle_file self : unit =
       Log.debug (fun k -> k "get-file: `%s`" file);
       let bytes =
         if file = "prelude" then
-          H.Byte_stream.of_string Builtin_config.config (* magic file! *)
+          H.IO.Input.of_string Builtin_config.config (* magic file! *)
         else (
-          try H.Byte_stream.of_chan @@ open_in file
+          try H.IO.Input.of_in_channel @@ open_in file
           with e ->
             H.Response.fail_raise ~code:404
               "cannot open file %S:\n\


### PR DESCRIPTION
To remove the: 

```
  warning 68: Missing field 'license'
```

When using `opam pin` or `opam lint`. 

I know this PR might seem nitpicky, but that's not the intention. I'm just trying to keep opam happy

EDIT: Btw, while I'm here, are there any plans for an opam release in the future?