### PR TITLE
Compatibility with printbox 0.12

### DIFF
--- a/benchpress-server.opam
+++ b/benchpress-server.opam
@@ -22,8 +22,8 @@ depends: [
   "sqlite3"
   "sqlite3_utils" { >= "0.4" & < "0.5" }
   "tiny_httpd" { >= "0.17" & < "1.0" }
-  "printbox" { >= "0.6" }
-  "printbox-text" { >= "0.6" }
+  "printbox" { >= "0.12" }
+  "printbox-text" { >= "0.12" }
   "ocaml" {>= "4.12" }
   "jemalloc" { >= "0.2" & < "0.3" }
 ]

--- a/src/server/benchpress_server.ml
+++ b/src/server/benchpress_server.ml
@@ -122,7 +122,7 @@ end = struct
           l
       in
       H.div a l
-    | B.Pad (_, b) | B.Frame b -> to_html_rec b
+    | B.Pad (_, b) | B.Frame { sub = b; _ } -> to_html_rec b
     | B.Align { h = `Right; inner = b; v = _ } ->
       H.div [ A.class_ "align-right" ] [ to_html_rec b ]
     | B.Align { h = `Center; inner = b; v = _ } ->


### PR DESCRIPTION
Not sure if there's a reason for benchpress to reimplement Printbox_html or if this simply predates that, but the build is broken with the latest Printbox release.