### PR TITLE
Migrate from containers-thread to moonpool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 jobs:
   run:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,9 @@ jobs:
           #- windows-latest  # depext issue for gnuplot/jemalloc?
           #- macos-latest # slow
         ocaml-compiler:
-          - 4.12.x
-          - 5.0.x
+          - 4.12.1
+          - 5.1.x
+          - 5.4.x
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           #- windows-latest  # depext issue for gnuplot/jemalloc?
           #- macos-latest # slow
         ocaml-compiler:
-          - 4.12.1
+          - 4.14.x
           - 5.1.x
           - 5.4.x
     runs-on: ${{ matrix.os }}

--- a/benchpress-lsp.opam
+++ b/benchpress-lsp.opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "dune" { >= "1.11" }
   "containers" { >= "3.0" & < "4.0" }
-  "containers-thread" { >= "3.0" & < "4.0" }
+  "moonpool" { >= "0.11" & < "0.12" }
   "benchpress" { = version }
   "linol" { >= "0.4" & < "0.5" }
 ]

--- a/benchpress-lsp.opam
+++ b/benchpress-lsp.opam
@@ -13,7 +13,7 @@ depends: [
   "containers" { >= "3.0" & < "4.0" }
   "moonpool" { >= "0.8" }
   "benchpress" { = version }
-  "linol" { >= "0.4" & < "0.5" }
+  "linol" { >= "0.10" & < "0.11" }
 ]
 homepage: "https://github.com/sneeuwballen/benchpress/"
 dev-repo: "git+https://github.com/sneeuwballen/benchpress.git"

--- a/benchpress-lsp.opam
+++ b/benchpress-lsp.opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "dune" { >= "1.11" }
   "containers" { >= "3.0" & < "4.0" }
-  "moonpool" { >= "0.9" }
+  "moonpool" { >= "0.8" }
   "benchpress" { = version }
   "linol" { >= "0.4" & < "0.5" }
 ]

--- a/benchpress-lsp.opam
+++ b/benchpress-lsp.opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "dune" { >= "1.11" }
   "containers" { >= "3.0" & < "4.0" }
-  "moonpool" { >= "0.11" & < "0.12" }
+  "moonpool" { >= "0.9" }
   "benchpress" { = version }
   "linol" { >= "0.4" & < "0.5" }
 ]

--- a/benchpress.opam
+++ b/benchpress.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" { >= "2.2" }
   "base-unix"
   "containers" { >= "3.3" & < "4.0" }
-  "moonpool" { >= "0.9" }
+  "moonpool" { >= "0.8" }
   "re" { >= "1.8" & < "2.0" }
   "csv"
   "cmdliner" {>= "1.1.0"}
@@ -29,7 +29,7 @@ depends: [
   "sqlite3_utils" { >= "0.4" & < "0.6" }
   "printbox" { >= "0.6" }
   "printbox-text" { >= "0.6" }
-  "ocaml" {>= "4.12" }
+  "ocaml" {>= "4.14" }
 ]
 homepage: "https://github.com/sneeuwballen/benchpress/"
 dev-repo: "git+https://github.com/sneeuwballen/benchpress.git"

--- a/benchpress.opam
+++ b/benchpress.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" { >= "2.2" }
   "base-unix"
   "containers" { >= "3.3" & < "4.0" }
-  "containers-thread" { >= "3.0" & < "4.0" }
+  "moonpool" { >= "0.11" & < "0.12" }
   "re" { >= "1.8" & < "2.0" }
   "csv"
   "cmdliner" {>= "1.1.0"}

--- a/benchpress.opam
+++ b/benchpress.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" { >= "2.2" }
   "base-unix"
   "containers" { >= "3.3" & < "4.0" }
-  "moonpool" { >= "0.11" & < "0.12" }
+  "moonpool" { >= "0.9" }
   "re" { >= "1.8" & < "2.0" }
   "csv"
   "cmdliner" {>= "1.1.0"}

--- a/src/bin/Run_main.ml
+++ b/src/bin/Run_main.ml
@@ -10,7 +10,7 @@ let execute_run_prover_action ?j ?cpus ?timestamp ?pp_results ?dyn ?limits
   Error.guard
     (Error.wrapf "run prover action@ `@[%a@]`" Action.pp_run_provers r)
   @@ fun () ->
-  let interrupted = CCLock.create false in
+  let interrupted = Moonpool.Lock.create false in
   let r =
     Exec_action.Exec_run_provers.expand ?dyn ?j ?cpus ?proof_dir ?limits defs
       r.limits r.j r.pattern r.dirs r.provers
@@ -23,7 +23,7 @@ let execute_run_prover_action ?j ?cpus ?timestamp ?pp_results ?dyn ?limits
   let result =
     Error.guard (Error.wrapf "running %d tests" len) @@ fun () ->
     Exec_action.Exec_run_provers.run ~uuid ?timestamp
-      ~interrupted:(fun () -> CCLock.get interrupted)
+      ~interrupted:(fun () -> Moonpool.Lock.get interrupted)
       ~on_solve:progress#on_res ~save ~wal_mode
       ~on_start_proof_check:(fun () -> progress#on_start_proof_check)
       ~on_proof_check:progress#on_proof_check_res
@@ -40,7 +40,7 @@ let execute_submit_job_action ?pp_results ?j ?timestamp ?dyn ?limits ?proof_dir
     (Error.wrapf "run provers with slurm action@ `@[%a@]`"
        Action.pp_run_provers_slurm r)
   @@ fun () ->
-  let interrupted = CCLock.create false in
+  let interrupted = Moonpool.Lock.create false in
   let exp_r =
     Exec_action.Exec_run_provers.expand ~slurm:true ?dyn ?j ?proof_dir ?limits
       defs r.limits r.j r.pattern r.dirs r.provers
@@ -53,7 +53,7 @@ let execute_submit_job_action ?pp_results ?j ?timestamp ?dyn ?limits ?proof_dir
   let result =
     Error.guard (Error.wrapf "running %d tests" len) @@ fun () ->
     Exec_action.Exec_run_provers.run_sbatch_job ~uuid ?timestamp
-      ~interrupted:(fun () -> CCLock.get interrupted)
+      ~interrupted:(fun () -> Moonpool.Lock.get interrupted)
       ?partition:r.partition ~nodes:r.nodes ~addr:r.addr ~port:r.port
       ~ntasks:r.ntasks ~save ~wal_mode ~on_solve:progress#on_res
       ~on_start_proof_check:(fun () -> progress#on_start_proof_check)

--- a/src/core/Exec_action.ml
+++ b/src/core/Exec_action.ml
@@ -290,7 +290,7 @@ end = struct
       in
       (* insert into DB here *)
       let ev_prover = Run_event.mk_prover result in
-      CCLock.with_lock db (fun db -> Run_event.to_db db ev_prover);
+      Moonpool.Lock.with_ db (fun db -> Run_event.to_db db ev_prover);
 
       let ev_proof =
         match result.res, proof_file with
@@ -320,7 +320,7 @@ end = struct
           on_proof_check res;
 
           (* insert into DB here *)
-          CCLock.with_lock db (fun db -> Run_event.to_db db ev_checker);
+          Moonpool.Lock.with_ db (fun db -> Run_event.to_db db ev_checker);
           [ ev_checker ]
         | _ -> []
       in
@@ -339,7 +339,7 @@ end = struct
     in
     (* run provers *)
     let res_l =
-      let db = CCLock.create db in
+      let db = Moonpool.Lock.create db in
       match self.j with
       | Bounded j ->
         Misc.Par_map.map_p ~j
@@ -446,7 +446,7 @@ end = struct
       let nb_resps = ref 0 in
       let resps_ref = ref [] in
       let resps_lock = Mutex.create () in
-      let db_wl = CCLock.create db in
+      let db_wl = Moonpool.Lock.create db in
       let add_resps evl =
         Mutex.lock resps_lock;
         nb_resps := !nb_resps + List.length evl;
@@ -456,7 +456,7 @@ end = struct
             (match ev with
             | Run_event.Prover_run r -> on_solve r
             | Checker_run r -> on_proof_check r);
-            CCLock.with_lock db_wl (fun db -> Run_event.to_db db ev))
+            Moonpool.Lock.with_ db_wl (fun db -> Run_event.to_db db ev))
           evl;
         Mutex.unlock resps_lock
       in
@@ -574,7 +574,7 @@ end = struct
     in
 
     let sock, used_port = Misc.mk_socket (Unix.ADDR_INET (addr, port)) in
-    ignore (CCThread.spawn (fun () -> Misc.start_server nodes server_loop sock));
+    ignore (Thread.create (fun () -> Misc.start_server nodes server_loop sock) ());
 
     Log.debug (fun k ->
         k "Spawned the thread that establishes a server listening at: %s:%s."

--- a/src/core/Misc.ml
+++ b/src/core/Misc.ml
@@ -7,10 +7,10 @@ module Db = Sqlite3_utils
 module PB = PrintBox
 
 let spf = Printf.sprintf
-let _lock = CCLock.create ()
+let _lock = Moonpool.Lock.create ()
 let now_s () = Ptime_clock.now () |> Ptime.to_float_s
 let reset_line = "\x1b[2K\r"
-let synchronized f = CCLock.with_lock _lock f
+let synchronized f = Moonpool.Lock.with_ _lock f
 
 module Log_report = struct
   let buf_fmt () =
@@ -41,7 +41,7 @@ module Log_report = struct
     | Logs.App -> Fmt.fprintf out "[@{<blue>app@}:%s]" src
 
   let reporter () =
-    let lock = CCLock.create () in
+    let lock = Moonpool.Lock.create () in
     Fmt.set_color_default true;
     let buf_out, buf_flush = buf_fmt () in
     let pp_header fmt header =
@@ -67,7 +67,7 @@ module Log_report = struct
     let report src level ~over k msgf =
       let k _ =
         let write_str out s =
-          CCLock.with_lock lock @@ fun () ->
+          Moonpool.Lock.with_ lock @@ fun () ->
           Printf.fprintf out "%s%s%!" reset_line s
         in
         let msg = buf_flush () in
@@ -301,22 +301,27 @@ module Par_map = struct
   let map_p ~j f l =
     if j < 1 then invalid_arg "map_p: ~j";
     die_on_sigterm ();
-    (* NOTE: for some reason the pool seems to spawn one too many thread
-       in some cases. So we add a guard to respect [-j] properly. *)
-    let sem = CCSemaphore.create j in
-    let f_with_sem x = CCSemaphore.with_acquire ~n:1 sem ~f:(fun () -> f x) in
-    Logs.debug (fun k -> k "par-map: create pool j=%d" j);
-    let module P = CCPool.Make (struct
-      let max_size = j
-    end) in
-    let res =
-      match l with
-      | [] -> []
-      | _ -> P.Fut.map_l (fun x -> P.Fut.make1 f_with_sem x) l |> P.Fut.get
-    in
-    Logs.debug (fun k -> k "par-map: stop pool");
-    P.stop ();
-    res
+    match l with
+    | [] -> []
+    | _ ->
+      Logs.debug (fun k -> k "par-map: create pool j=%d" j);
+      let pool = Moonpool.Fifo_pool.create ~num_threads:j () in
+      let res =
+        try
+          let futs = List.map (fun x -> Moonpool.Fut.spawn ~on:pool (fun () -> f x)) l in
+          let results = List.map Moonpool.Fut.wait_block futs in
+          List.map (function
+            | Ok x -> x
+            | Error (exn, bt) -> Printexc.raise_with_backtrace exn bt
+          ) results
+        with e ->
+          Logs.debug (fun k -> k "par-map: shutdown pool (exception)");
+          Moonpool.Fifo_pool.shutdown pool;
+          raise e
+      in
+      Logs.debug (fun k -> k "par-map: shutdown pool");
+      Moonpool.Fifo_pool.shutdown pool;
+      res
 
   (* Map on the list [l] with each call to [f] being associated one of the
      resources from [resources] that is guaranteed not to be used concurrently
@@ -329,21 +334,35 @@ module Par_map = struct
         invalid_arg "map_with_resource: ~resources";
       die_on_sigterm ();
       let jobs = List.length resources in
-      let queue = CCBlockingQueue.create jobs in
-      List.iter (CCBlockingQueue.push queue) resources;
-      let f x =
-        let resource = CCBlockingQueue.take queue in
+      let queue = Moonpool.Blocking_queue.create () in
+      List.iter (Moonpool.Blocking_queue.push queue) resources;
+      let f_with_resource x =
+        let resource = Moonpool.Blocking_queue.pop queue in
         Fun.protect
-          ~finally:(fun () -> CCBlockingQueue.push queue resource)
+          ~finally:(fun () -> Moonpool.Blocking_queue.push queue resource)
           (fun () -> f resource x)
       in
       Logs.debug (fun m -> m "par-map: create pool j=%d" jobs);
-      let module P = CCPool.Make (struct
-        let max_size = jobs
-      end) in
-      let res = P.Fut.map_l (P.Fut.make1 f) l |> P.Fut.get in
-      Logs.debug (fun m -> m "par-map: stop pool");
-      P.stop ();
+      let pool = Moonpool.Fifo_pool.create ~num_threads:jobs () in
+      let res =
+        try
+          let futs = List.map (fun x ->
+            Moonpool.Fut.spawn ~on:pool (fun () -> f_with_resource x)
+          ) l in
+          let results = List.map Moonpool.Fut.wait_block futs in
+          Moonpool.Blocking_queue.close queue;
+          List.map (function
+            | Ok x -> x
+            | Error (exn, bt) -> Printexc.raise_with_backtrace exn bt
+          ) results
+        with e ->
+          Logs.debug (fun m -> m "par-map: shutdown pool (exception)");
+          Moonpool.Blocking_queue.close queue;
+          Moonpool.Fifo_pool.shutdown pool;
+          raise e
+      in
+      Logs.debug (fun m -> m "par-map: shutdown pool");
+      Moonpool.Fifo_pool.shutdown pool;
       res
 end
 
@@ -464,12 +483,17 @@ let mk_socket sockaddr =
 let start_server n server_fun sock =
   let open Unix in
   listen sock 5;
-  CCThread.Arr.join
-  @@ CCThread.Arr.spawn n (fun _ ->
-         let s, _caller = accept_non_intr sock in
-         let inchan = in_channel_of_descr s in
-         let outchan = out_channel_of_descr s in
-         server_fun inchan outchan)
+  let threads =
+    List.init n (fun _ ->
+      Thread.create (fun () ->
+        let s, _caller = accept_non_intr sock in
+        let inchan = in_channel_of_descr s in
+        let outchan = out_channel_of_descr s in
+        server_fun inchan outchan
+      ) ()
+    )
+  in
+  List.iter Thread.join threads
 
 (** [establish_server n server_fun sockaddr] same as
     [Unix.establish_server], but it uses threads instead of forking the process

--- a/src/core/Task_queue.ml
+++ b/src/core/Task_queue.ml
@@ -1,7 +1,7 @@
 (** {1 Task queue for the server} *)
 
 open Common
-module M = CCLock
+module M = Moonpool.Lock
 module Log = (val Logs.src_log (Logs.Src.create "benchpress.task-queue"))
 
 type job = {
@@ -40,14 +40,14 @@ type api_job = { mutable aj_last_seen: float; mutable aj_interrupted: bool }
 
 type t = {
   defs: Definitions.t M.t;
-  jobs: job CCBlockingQueue.t;
+  jobs: job Moonpool.Blocking_queue.t;
   jobs_tbl: (string, Job.t) Hashtbl.t;
   api_jobs: (string, api_job) Hashtbl.t; (* last seen+descr *)
   cur: job option M.t;
 }
 
 let defs self = self.defs
-let size self = CCBlockingQueue.size self.jobs
+let size self = Moonpool.Blocking_queue.size self.jobs
 let cur_job self = M.get self.cur
 
 let interrupt self ~uuid : bool =
@@ -62,7 +62,7 @@ let interrupt self ~uuid : bool =
 
 let create ?(defs = Definitions.empty) () : t =
   {
-    jobs = CCBlockingQueue.create 64;
+    jobs = Moonpool.Blocking_queue.create ();
     defs = M.create defs;
     jobs_tbl = Hashtbl.create 8;
     api_jobs = Hashtbl.create 8;
@@ -85,11 +85,11 @@ let push self task : unit =
     }
   in
   Hashtbl.add self.jobs_tbl j_uuid j;
-  CCBlockingQueue.push self.jobs j
+  Moonpool.Blocking_queue.push self.jobs j
 
 let loop self =
   while true do
-    let job = CCBlockingQueue.take self.jobs in
+    let job = Moonpool.Blocking_queue.pop self.jobs in
     Profile.with_ "task-queue.job" @@ fun () ->
     job.j_started_time <- Unix.gettimeofday ();
     M.set self.cur (Some job);

--- a/src/core/Task_queue.mli
+++ b/src/core/Task_queue.mli
@@ -17,7 +17,7 @@ type t
 
 val create : ?defs:Definitions.t -> unit -> t
 
-val defs : t -> Definitions.t CCLock.t
+val defs : t -> Definitions.t Moonpool.Lock.t
 (** List of definitions available for tasks *)
 
 val size : t -> int

--- a/src/core/dune
+++ b/src/core/dune
@@ -5,7 +5,7 @@
  (synopsis
    "Benchpress core library, with all the data structures and functions")
  (wrapped true)
- (libraries containers containers.unix containers-thread re re.perl csv iter
+ (libraries containers containers.unix moonpool re re.perl csv iter
    printbox printbox-text logs logs.cli gnuplot ptime ptime.clock.os uuidm
    sqlite3 sqlite3_utils cmdliner pp_loc processor)
  (flags :standard -w -5 -warn-error -a+8 -strict-sequence))

--- a/src/core/profile.ml
+++ b/src/core/profile.ml
@@ -2,7 +2,7 @@ let spf = Printf.sprintf
 
 type span = float
 
-let out_ : out_channel CCLock.t option ref = ref None
+let out_ : out_channel Moonpool.Lock.t option ref = ref None
 let[@inline] enabled () = !out_ != None
 let start_ = Unix.gettimeofday ()
 let[@inline] now_us () = (Unix.gettimeofday () -. start_) *. 1e6
@@ -15,11 +15,11 @@ let enable () =
     (*     let oc = Unix.open_process_out "gzip --synchronous -c - > trace.json.gz" in *)
     let oc = open_out "trace.json" in
     output_string oc "[";
-    let out = CCLock.create oc in
+    let out = Moonpool.Lock.create oc in
     out_ := Some out;
     at_exit (fun () ->
         out_ := None;
-        CCLock.with_lock out (fun oc ->
+        Moonpool.Lock.with_ out (fun oc ->
             flush oc;
             close_out_noerr oc))
   )
@@ -44,7 +44,7 @@ let exit_real_ ?(args = []) sp name =
         {json|{"ph":"X","name":%S,"pid":1,"tid":%d,"ts":%.1f,"dur":%.1f%s},|json}
         name tid sp dur args
     in
-    CCLock.with_lock out (fun oc ->
+    Moonpool.Lock.with_ out (fun oc ->
         output_string oc s;
         output_char oc '\n';
         flush oc)

--- a/src/lsp/benchpress_lsp.ml
+++ b/src/lsp/benchpress_lsp.ml
@@ -10,7 +10,7 @@ type 'a or_error = ('a, Error.t) result
 module E = CCResult
 module IO = Linol.Blocking_IO
 module L = Linol.Jsonrpc2.Make (IO)
-module LT = Lsp.Types
+module LT = Linol.Lsp.Types
 module Log = (val Logs.src_log Logs.Src.(create "lsp"))
 
 type loc = Loc.t
@@ -21,12 +21,14 @@ type processed_buf = {
   defs: Definitions.t or_error;
 }
 
-let range_of_loc_ (l : loc) : Lsp.Types.Range.t =
+let uri_to_string = LT.DocumentUri.to_string
+
+let range_of_loc_ (l : loc) : Linol.Lsp.Types.Range.t =
   let mk_pos_ p =
     let line, col = Loc.Pos.to_line_col l.input p in
-    Lsp.Types.Position.create ~line:(line - 1) ~character:col
+    Linol.Lsp.Types.Position.create ~line:(line - 1) ~character:col
   in
-  Lsp.Types.Range.create ~start:(mk_pos_ l.start) ~end_:(mk_pos_ l.stop)
+  Linol.Lsp.Types.Range.create ~start:(mk_pos_ l.start) ~end_:(mk_pos_ l.stop)
 
 let diag_of_error ~uri (e0 : Error.t) : LT.Diagnostic.t list =
   let e, ctx = Error.unwrap_ctx e0 in
@@ -46,12 +48,12 @@ let diag_of_error ~uri (e0 : Error.t) : LT.Diagnostic.t list =
 
   match errs with
   | [] ->
-    Log.err (fun k -> k "in %s: err with no loc:@ %a" uri Error.pp e0);
+    Log.err (fun k -> k "in %s: err with no loc:@ %a" (uri_to_string uri) Error.pp e0);
     []
   | (msg0, loc0) :: ctx_errs ->
     let d =
       LT.Diagnostic.create ~severity:LT.DiagnosticSeverity.Error
-        ~range:(range_of_loc_ loc0) ~message:msg0
+        ~range:(range_of_loc_ loc0) ~message:(`String msg0)
         ~relatedInformation:(List.map tr_ctx_err_ ctx_errs)
         ()
     in
@@ -68,7 +70,7 @@ let diagnostics ~uri (p : processed_buf) : _ list =
     in
     let errors = List.rev_append (Stanza.errors l) defs_errors in
     Log.debug (fun k ->
-        k "in %s: ok, %d stanzas, %d errors" uri (List.length l)
+        k "in %s: ok, %d stanzas, %d errors" (uri_to_string uri) (List.length l)
           (List.length errors));
     CCList.flat_map (diag_of_error ~uri) errors
   | Error e0 -> diag_of_error ~uri e0
@@ -100,8 +102,10 @@ class blsp =
     inherit L.server
 
     (* one env per document *)
-    val buffers : (Lsp.Types.DocumentUri.t, processed_buf) Hashtbl.t Lock.t =
+    val buffers : (Linol.Lsp.Types.DocumentUri.t, processed_buf) Hashtbl.t Lock.t =
       Lock.create @@ Hashtbl.create 32
+
+    method spawn_query_handler f = ignore (Thread.create (fun () -> f ()) ())
 
     method! config_hover = Some (`Bool true)
     method! config_definition = Some (`Bool true)
@@ -114,10 +118,10 @@ class blsp =
     method! config_sync_opts =
       let change = LT.TextDocumentSyncKind.Incremental in
       LT.TextDocumentSyncOptions.create ~openClose:true ~change
-        ~save:(LT.SaveOptions.create ~includeText:false ())
+        ~save:(`SaveOptions (LT.SaveOptions.create ~includeText:false ()))
         ()
 
-    method! on_req_hover ~notify_back:_ ~id:_ ~uri ~pos (_ : L.doc_state)
+    method! on_req_hover ~notify_back:_ ~id:_ ~uri ~pos ~workDoneToken:_ (_ : L.doc_state)
         : LT.Hover.t option =
       let pos = Loc.Pos.of_line_col pos.L.Position.line pos.character in
       match Lock.with_ buffers (fun b -> CCHashtbl.get b uri) with
@@ -142,7 +146,7 @@ class blsp =
             Some h))
       | _ -> None
 
-    method! on_req_definition ~notify_back:_ ~id:_ ~uri ~pos (_ : L.doc_state)
+    method! on_req_definition ~notify_back:_ ~id:_ ~uri ~pos ~workDoneToken:_ ~partialResultToken:_ (_ : L.doc_state)
         : LT.Locations.t option =
       let pos = Loc.Pos.of_line_col pos.L.Position.line pos.character in
       match Lock.with_ buffers (fun b -> CCHashtbl.get b uri) with
@@ -165,13 +169,13 @@ class blsp =
 
     (* FIXME: completion is never useful on a parsable buffer, and
        buffers that do not parse have no definitions *)
-    method! on_req_completion ~notify_back:_ ~id:_ ~uri ~pos ~ctx:_
+    method! on_req_completion ~notify_back:_ ~id:_ ~uri ~pos ~ctx:_ ~workDoneToken:_ ~partialResultToken:_
         (_ : L.doc_state)
         : [ `CompletionList of LT.CompletionList.t
           | `List of LT.CompletionItem.t list ]
           option =
       Log.debug (fun k ->
-          k "completion request in '%s' at pos: %d line, %d col" uri pos.line
+          k "completion request in '%s' at pos: %d line, %d col" (uri_to_string uri) pos.line
             pos.character);
       let pos = Loc.Pos.of_line_col pos.line pos.character in
       match Lock.with_ buffers (fun b -> CCHashtbl.get b uri) with
@@ -203,12 +207,12 @@ class blsp =
        - return the diagnostics from the new state
     *)
     method private _on_doc ~(notify_back : L.notify_back)
-        (uri : Lsp.Types.DocumentUri.t) (contents : string) =
-      Log.debug (fun k -> k "on doc %s" uri);
+        (uri : Linol.Lsp.Types.DocumentUri.t) (contents : string) =
+      Log.debug (fun k -> k "on doc %s" (uri_to_string uri));
       let open E.Infix in
       let stanzas =
         catch_e @@ fun () ->
-        Stanza.parse_string ~reify_errors:true ~filename:uri contents
+        Stanza.parse_string ~reify_errors:true ~filename:(uri_to_string uri) contents
       in
       let defs =
         let* stanzas = stanzas in
@@ -217,7 +221,7 @@ class blsp =
       let pdoc = { stanzas; defs; text = contents } in
       Lock.with_ buffers (fun b -> Hashtbl.replace b uri pdoc);
       let diags = diagnostics ~uri pdoc in
-      Log.debug (fun k -> k "send diags for %s" uri);
+      Log.debug (fun k -> k "send diags for %s" (uri_to_string uri));
       notify_back#send_diagnostic diags
 
     (* We now override the [on_notify_doc_did_open] method that will be called
@@ -237,7 +241,7 @@ class blsp =
        hashtable state, to avoid leaking memory. *)
     method on_notif_doc_did_close ~notify_back:_
         (d : LT.TextDocumentIdentifier.t) : unit IO.t =
-      Log.debug (fun k -> k "close %s" d.uri);
+      Log.debug (fun k -> k "close %s" (uri_to_string d.uri));
       Lock.with_ buffers (fun b -> Hashtbl.remove b d.uri);
       IO.return ()
   end

--- a/src/lsp/benchpress_lsp.ml
+++ b/src/lsp/benchpress_lsp.ml
@@ -3,7 +3,7 @@ module Stanza = Benchpress.Stanza
 module Error = Benchpress.Error
 module Definitions = Benchpress.Definitions
 module Sexp_loc = Benchpress.Sexp_loc
-module Lock = CCLock
+module Lock = Moonpool.Lock
 
 type 'a or_error = ('a, Error.t) result
 
@@ -120,7 +120,7 @@ class blsp =
     method! on_req_hover ~notify_back:_ ~id:_ ~uri ~pos (_ : L.doc_state)
         : LT.Hover.t option =
       let pos = Loc.Pos.of_line_col pos.L.Position.line pos.character in
-      match Lock.with_lock buffers (fun b -> CCHashtbl.get b uri) with
+      match Lock.with_ buffers (fun b -> CCHashtbl.get b uri) with
       | Some { defs = Ok defs; text; _ } ->
         Log.debug (fun k -> k "found buffer with defs");
         (match find_atom_under_ text pos with
@@ -145,7 +145,7 @@ class blsp =
     method! on_req_definition ~notify_back:_ ~id:_ ~uri ~pos (_ : L.doc_state)
         : LT.Locations.t option =
       let pos = Loc.Pos.of_line_col pos.L.Position.line pos.character in
-      match Lock.with_lock buffers (fun b -> CCHashtbl.get b uri) with
+      match Lock.with_ buffers (fun b -> CCHashtbl.get b uri) with
       | Some { defs = Ok defs; text; _ } ->
         Log.debug (fun k -> k "found buffer with defs");
         (match find_atom_under_ text pos with
@@ -174,7 +174,7 @@ class blsp =
           k "completion request in '%s' at pos: %d line, %d col" uri pos.line
             pos.character);
       let pos = Loc.Pos.of_line_col pos.line pos.character in
-      match Lock.with_lock buffers (fun b -> CCHashtbl.get b uri) with
+      match Lock.with_ buffers (fun b -> CCHashtbl.get b uri) with
       | Some { defs = Ok defs; text; _ } ->
         Log.debug (fun k -> k "found local doc");
         (match find_atom_under_ text pos with
@@ -215,7 +215,7 @@ class blsp =
         catch_e @@ fun () -> Definitions.of_stanza_l ~reify_errors:true stanzas
       in
       let pdoc = { stanzas; defs; text = contents } in
-      Lock.with_lock buffers (fun b -> Hashtbl.replace b uri pdoc);
+      Lock.with_ buffers (fun b -> Hashtbl.replace b uri pdoc);
       let diags = diagnostics ~uri pdoc in
       Log.debug (fun k -> k "send diags for %s" uri);
       notify_back#send_diagnostic diags
@@ -238,7 +238,7 @@ class blsp =
     method on_notif_doc_did_close ~notify_back:_
         (d : LT.TextDocumentIdentifier.t) : unit IO.t =
       Log.debug (fun k -> k "close %s" d.uri);
-      Lock.with_lock buffers (fun b -> Hashtbl.remove b d.uri);
+      Lock.with_ buffers (fun b -> Hashtbl.remove b d.uri);
       IO.return ()
   end
 

--- a/src/lsp/dune
+++ b/src/lsp/dune
@@ -4,4 +4,4 @@
  (modes native)
  (package benchpress-lsp)
  (flags :standard -warn-error -a+8 -safe-string)
- (libraries containers containers-thread benchpress linol))
+ (libraries containers moonpool benchpress linol))


### PR DESCRIPTION
Replace containers-thread with moonpool for parallel execution. Pool size enforces parallelism, blocking queue manages CPU affinity resources.